### PR TITLE
don't handle rateTolerance with new x265 builds

### DIFF
--- a/avidemux_plugins/ADM_videoEncoder/x265/ADM_x265Setup.cpp
+++ b/avidemux_plugins/ADM_videoEncoder/x265/ADM_x265Setup.cpp
@@ -215,7 +215,9 @@ bool x265Encoder::setup(void)
   #define MKPARAMB(x,y) {param.rc.x = x265Settings.ratecontrol.y ;aprintf("[x265] rc."#x" = %s\n",TrueFalse[param.rc.x&1]);}
 
       MKPARAM(qpStep,qp_step);
+#if X265_BUILD < 41
       MKPARAM(rateTolerance,rate_tolerance);
+#endif
       MKPARAM(ipFactor,ip_factor);
       MKPARAM(pbFactor,pb_factor);
       MKPARAMB(cuTree,cu_tree);
@@ -394,7 +396,9 @@ void dumpx265Setup(x265_param *param)
     RI(rateControlMode);
     RI(qp);
     RI(bitrate);
+#if X265_BUILD < 41
     RD(rateTolerance);
+#endif
     RD(qCompress);
     RD(ipFactor);
     RD(pbFactor);


### PR DESCRIPTION
rateTolerance was removed in the middle of X265_BUILD=41

see http://avidemux.org/smuf/index.php/topic,16353.0.html