### PR TITLE
[qt4] Open video files in LASTFILES_LASTDIR_READ directory

### DIFF
--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/file_qt4.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/file_qt4.cpp
@@ -113,7 +113,7 @@ static	void GUI_FileSelSelectReadInternal(const char *label, const char *ext, ch
                 QFileDialog::Options opts;
               
                 //printf("Do filer=%d\n",(int)doFilter);
-                if (prefs->get(LASTFILES_LASTDIR_WRITE,&tmpname))
+                if (prefs->get(LASTFILES_LASTDIR_READ,&tmpname))
 		{
                         
                         str = QFileInfo(QString::fromUtf8(tmpname)).path();


### PR DESCRIPTION
In current avidemux 2.6.10 the File->Open file browser opens in the
LASTFILES_LASTDIR_WRITE directory, which is updated whenever a file
is written.

This patch corrects this behaviour to open the browser in the last
directory that has been read from.