### PR TITLE
[qt4] Provide a default filename when saving

### DIFF
--- a/avidemux/common/gui_save.cpp
+++ b/avidemux/common/gui_save.cpp
@@ -100,12 +100,16 @@ void HandleAction_Save(Action action)
       GUI_FileSelWrite (QT_TRANSLATE_NOOP("adm","Select JPEG Sequence to Save"), (SELFILE_CB *)A_saveBunchJpg);
     	break;
     case ACT_SAVE_BMP:
-      GUI_FileSelWrite (QT_TRANSLATE_NOOP("adm","Select BMP to Save"), (SELFILE_CB *)A_saveImg);
-      //GUI_FileSelWrite ("Select Jpg to save ", A_saveJpg);
+    {
+      const char *defaultExtension="bmp";
+      GUI_FileSelWriteExtension (QT_TRANSLATE_NOOP("adm","Select BMP to Save"),defaultExtension,(SELFILE_CB *)A_saveImg); // A_saveImg);
+    }
       break;
     case ACT_SAVE_JPG :
-      GUI_FileSelWrite (QT_TRANSLATE_NOOP("adm","Select JPEG to Save"), (SELFILE_CB *)A_saveJpg);
-      	//GUI_FileSelWrite ("Select Jpg to save ", A_saveJpg);
+    {
+      const char *defaultExtension="jpg";
+      GUI_FileSelWriteExtension (QT_TRANSLATE_NOOP("adm","Select JPEG to Save"),defaultExtension,(SELFILE_CB *)A_saveJpg); // A_saveJpg);
+    }
       	break;
 //----------------------test-----------------------
     case ACT_SAVE_VIDEO:
@@ -385,7 +389,7 @@ int A_saveImg (const char *name)
   ADMImage *image=admPreview::getBuffer();
     if(!image)
     {
-        ADM_warning("[SaveJpeg] No image\n");
+        ADM_warning("[SaveBmp] No image\n");
         return 0;
 
     }

--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/file_qt4.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/file_qt4.cpp
@@ -49,10 +49,25 @@ static	void GUI_FileSelSelectWriteInternal(const char *label, const char *ext, c
                 //printf("Do filer=%d\n",(int)doFilter);
                 if (prefs->get(LASTFILES_LASTDIR_WRITE,&tmpname))
 		{
-                        
-                        str = QFileInfo(QString::fromUtf8(tmpname)).path();
+                        QString outputPath = QFileInfo(QString::fromUtf8(tmpname)).path();
+
+                        char *tmpinputname = NULL;
+                        QString inputBaseName = QString("");
+                        if (prefs->get(LASTFILES_LASTDIR_READ,&tmpinputname))
+                        {
+                            inputBaseName = QFileInfo(QString::fromUtf8(tmpinputname)).completeBaseName();
+                        }
+
+                        QString outputExt = QString("");
+                        if (doFilter)
+                        {
+                            outputExt = dot+QString(ext);
+                        }
+                        QString separator = QString("/");
+                        str = outputPath+separator+inputBaseName+outputExt;
+
                 	/* LASTDIR may have gone; then do nothing and use current dir instead (implied) */
-			if (!QDir(str).exists())
+			if (!QDir(outputPath).exists())
                                 str.clear();
 		}
 		


### PR DESCRIPTION
Provide a default (selected) filename when saving video, or when saving
a video frame to BMP/JPEG.

The default filename is constructed from the basename of the current open
video, with an extension determined by the output container/image format.

If the user does not want to use the default filename, they can simply
start typing to replace the selected filename with one of their choosing.

This update also has the effect of filtering the files displayed in the
FileDialog to those having the same extension.