### PR TITLE
[qt4] Avoid overwriting output files when saving video/images

### DIFF
--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/file_qt4.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/file_qt4.cpp
@@ -80,19 +80,19 @@ static	void GUI_FileSelSelectWriteInternal(const char *label, const char *ext, c
                             strcat(*name,"."); strcat(*name,ext);
 
                             fileName=fileName+QString(".")+QString(ext);
-                            QFile newFile(fileName);
-                            if(newFile.exists())
-                            {
-                                QFileInfo fileInfo(newFile);
-                                QString q=QString("Overwrite file ")+fileInfo.fileName()+QString("?");
-                                if(!GUI_Question(q.toUtf8().constData()))
-                                {
-                                    ADM_dezalloc(*name);
-                                    *name=NULL;
-                                    return;
-                                }
-                            }
                         }
+                }
+                QFile newFile(fileName);
+                if(newFile.exists())
+                {
+                    QFileInfo fileInfo(newFile);
+                    QString q=QString("Overwrite file ")+fileInfo.fileName()+QString("?");
+                    if(!GUI_Question(q.toUtf8().constData()))
+                    {
+                        ADM_dezalloc(*name);
+                        *name=NULL;
+                        return;
+                    }
                 }
                 prefs->set(LASTFILES_LASTDIR_WRITE, fileName.toUtf8().constData());
 	}


### PR DESCRIPTION
Always prompt the user before overwriting a file in the output directory
which has the same filename, when file filtering in the FileDialog is enabled.

This change should be applied after the update to provide a default filename
(including extension) when saving video/images.

Currently:

When file filtering is enabled, a file extension is automatically
added when the output filename does not contain a dot ("."). This is also
the time when ADM checks if the output file exists after adding the
filtering extension.

With ADM updated to suggest a default filename when saving, this file check
might not happen (because the output filename will probably already contain
a dot (".")).

This update tries to ensure that the user is always prompted before
overwriting a file when saving.