### PR TITLE
Fix typos and improve consistency of some error messages

### DIFF
--- a/avidemux/common/ADM_editor/src/ADM_edit.cpp
+++ b/avidemux/common/ADM_editor/src/ADM_edit.cpp
@@ -241,7 +241,7 @@ bool ADM_Composer::addFile (const char *name)
                  (strlen(str)?" and ":""),
                  (strlen(str)?" are ":" is ") );
          str[512] = '\0';
-         GUI_Error_HIG(str,QT_TR_NOOP("You cannot mix different video dimensions yet. Using the partial video filter later, will not work around this problem. The workaround is:\n1.) \"resize\" / \"add border\" / \"crop\" each stream to the same resolution\n2.) concatinate them together"));
+         GUI_Error_HIG(str,QT_TR_NOOP("You cannot mix different video dimensions yet. Using the partial video filter later, will not work around this problem. The workaround is:\n1.) \"resize\" / \"add border\" / \"crop\" each stream to the same resolution\n2.) concatenate them together"));
          delete video._aviheader;
          return false;
       }

--- a/avidemux/common/ADM_videoCodec/src/ADM_ffmpeg_libva.cpp
+++ b/avidemux/common/ADM_videoCodec/src/ADM_ffmpeg_libva.cpp
@@ -80,7 +80,7 @@ bool libvaProbe(void)
 #ifdef USE_LIBVA
     if( admCoreCodecSupports(ADM_CORE_CODEC_FEATURE_LIBVA)==false)
     {
-        GUI_Error_HIG("Error","Core has been compiled without libva support, but the application has been compiled with it.\nInstallation mismatch");
+        GUI_Error_HIG("Error","Core has been compiled without LIBVA support, but the application has been compiled with it.\nInstallation mismatch");
         libvaWorking=false;
     }
 
@@ -271,7 +271,7 @@ decoderFFLIBVA::decoderFFLIBVA(uint32_t w, uint32_t h,uint32_t fcc, uint32_t ext
             }
             else
             {
-                GUI_Error_HIG("Error","LibVA does not support this, configuration error"); 
+                GUI_Error_HIG("Error","LIBVA does not support this, configuration error");
                 ADM_assert(0);
             }
         }

--- a/avidemux/common/ADM_videoCodec/src/ADM_ffmpeg_vdpau.cpp
+++ b/avidemux/common/ADM_videoCodec/src/ADM_ffmpeg_vdpau.cpp
@@ -151,7 +151,7 @@ bool vdpauProbe(void)
 #ifdef USE_VDPAU
     if( admCoreCodecSupports(ADM_CORE_CODEC_FEATURE_VDPAU)==false)
     {
-        GUI_Error_HIG("Error","Core has been compiled without vdpau support, but the application has been compiled with it.\nInstallation mismatch");
+        GUI_Error_HIG("Error","Core has been compiled without VDPAU support, but the application has been compiled with it.\nInstallation mismatch");
         vdpauWorking=false;
     }
 #endif

--- a/avidemux/common/ADM_videoCodec/src/ADM_ffmpeg_xvba.cpp
+++ b/avidemux/common/ADM_videoCodec/src/ADM_ffmpeg_xvba.cpp
@@ -131,7 +131,7 @@ bool xvbaProbe(void)
 #ifdef USE_XVBA
     if( admCoreCodecSupports(ADM_CORE_CODEC_FEATURE_XVBA)==false)
     {
-        GUI_Error_HIG("Error","Core has been compiled without xvba support, but the application has been compiled with it.\nInstallation mismatch");
+        GUI_Error_HIG("Error","Core has been compiled without XVBA support, but the application has been compiled with it.\nInstallation mismatch");
         xvbaWorking=false;
     }
 

--- a/avidemux/common/gui_autodrive.cpp
+++ b/avidemux/common/gui_autodrive.cpp
@@ -154,7 +154,7 @@ uint8_t A_autoDrive(Action action)
                             if(!videoCodecSelectByName("FFMpeg4"))            
 #endif
                             {
-                              GUI_Error_HIG(QT_TRANSLATE_NOOP("adm","Codec Error"),QT_TRANSLATE_NOOP("adm", "Cannot select mpeg4 sp codec."));
+                              GUI_Error_HIG(QT_TRANSLATE_NOOP("adm","Codec Error"),QT_TRANSLATE_NOOP("adm", "Cannot select MPEG-4 SP codec."));
                                 return 0;
                             }
                             // Set mode & bitrate 

--- a/avidemux/common/gui_main.cpp
+++ b/avidemux/common/gui_main.cpp
@@ -1137,7 +1137,7 @@ void A_externalAudioTrack(const char *trackIdxTxt, const char *filename )
 		}
 		if (assumedIdx == -1) {
 			// This should never happen, but who knows?
-			GUI_Error_HIG("Error","Audio file not found in list, even than it should be there. Create a bug report!");
+			GUI_Error_HIG("Error","Audio file not found in list, even though it should be there. Create a bug report!");
 			return;
 		}
 		printf("assumed Idx = %d\n", assumedIdx);

--- a/avidemux/common/gui_navigate.cpp
+++ b/avidemux/common/gui_navigate.cpp
@@ -459,7 +459,7 @@ bool GUI_GoToTime(uint64_t time)
     // We have to call the editor as the frames needed to decode the target frame may be hidden
     if(false==video_body->goToTimeVideo(time))
     {
-        GUI_Error_HIG("Seek", "Error seekting to %"PRIu64" ms",time/1000);
+        GUI_Error_HIG("Seek", "Error seeking to %"PRIu64" ms",time/1000);
     }
     admPreview::samePicture();
     GUI_setCurrentFrameAndTime();

--- a/avidemux/common/gui_savenew.cpp
+++ b/avidemux/common/gui_savenew.cpp
@@ -295,7 +295,7 @@ ADM_videoStream *admSaver::setupVideo(void)
         chain=createVideoFilterChain(markerA,markerB);
         if(!chain)
         {
-                GUI_Error_HIG("Video","Cannot instantiante video Chain");
+                GUI_Error_HIG("Video","Cannot instantiate video chain");
                 return NULL;
         }
         // 2- Create Encoder
@@ -323,7 +323,7 @@ ADM_videoStream *admSaver::setupVideo(void)
         }
         if(encoder->setup()==false)
         {
-            GUI_Error_HIG("Video","Cannot setup codec. Bitrate too low ?");
+            GUI_Error_HIG("Video","Cannot setup codec. Bitrate too low?");
             delete encoder;
             encoder=NULL;
             return NULL;
@@ -409,7 +409,7 @@ bool admSaver::save(void)
 
     if(!(muxer=ADM_MuxerSpawnFromIndex(muxerIndex)))
     {
-        GUI_Error_HIG("Muxer","Cannot instantiante muxer");
+        GUI_Error_HIG("Muxer","Cannot instantiate muxer");
         return 0;
     }
      

--- a/avidemux_plugins/ADM_muxers/muxerAvi/muxerAvi.cpp
+++ b/avidemux_plugins/ADM_muxers/muxerAvi/muxerAvi.cpp
@@ -81,7 +81,7 @@ bool muxerAvi::open(const char *file, ADM_videoStream *s,uint32_t nbAudioTrack,A
              nbAudioTrack,
              a))
         {
-            GUI_Error_HIG("Error","Cannot create avi file");
+            GUI_Error_HIG("Error","Cannot create AVI file");
             return false;
 
         }

--- a/avidemux_plugins/ADM_muxers/muxerMp4v2/muxerMp4v2.cpp
+++ b/avidemux_plugins/ADM_muxers/muxerMp4v2/muxerMp4v2.cpp
@@ -237,7 +237,7 @@ bool muxerMp4v2::save(void)
         ADM_assert(in[nextWrite].dts!=ADM_NO_PTS)
         if(in[other].pts==ADM_NO_PTS || in[other].pts==ADM_NO_PTS)
         {
-            GUI_Error_HIG("Video","Video does not have enough timing information. Are you copying from AVI ?");
+            GUI_Error_HIG("Video","Video does not have enough timing information. Are you copying from AVI?");
             goto theEnd;
         }
 

--- a/avidemux_plugins/ADM_muxers/muxerMp4v2/muxerMp4v2Audio.cpp
+++ b/avidemux_plugins/ADM_muxers/muxerMp4v2/muxerMp4v2Audio.cpp
@@ -50,7 +50,7 @@ bool muxerMp4v2::addAc3(int index, WAVHeader *header)
                 case 32000: fscod=2;break;
                 default: 
                     {
-                    GUI_Error_HIG("", "invalid frequency for AC3. Only 32, 44.1 & 48 kHz");
+                    GUI_Error_HIG("", "Invalid frequency for AC3. Only 32, 44.1 & 48 kHz");
                     return false;
                     }
         }
@@ -82,7 +82,7 @@ bool muxerMp4v2::addAc3(int index, WAVHeader *header)
                 case 6: acmod=7;lfe=1;break;
                 default: 
                         {
-                                  GUI_Error_HIG("","Invalid number of channel for AC3");
+                                  GUI_Error_HIG("","Invalid number of channels for AC3");
                                   return false;
                         }
         }

--- a/avidemux_plugins/ADM_muxers/muxerWebm/muxerWebm.cpp
+++ b/avidemux_plugins/ADM_muxers/muxerWebm/muxerWebm.cpp
@@ -63,7 +63,7 @@ bool muxerWebm::open(const char *file, ADM_videoStream *s,uint32_t nbAudioTrack,
     uint32_t fcc=s->getFCC();
     if(!fourCC::check(fcc,(const uint8_t *)"VP8 ") && !fourCC::check(fcc,(const uint8_t *)"VP9 "))
     {
-        GUI_Error_HIG("Webm","Unsupported Video.\nOnly VP8/VP9 Video and Vorbis/Opus audio supported");
+        GUI_Error_HIG("Webm","Unsupported Video.\nOnly VP8/VP9 video and Vorbis/Opus audio supported");
         return false;
     }
     for( int i=0;i<nbAudioTrack;i++)
@@ -75,7 +75,7 @@ bool muxerWebm::open(const char *file, ADM_videoStream *s,uint32_t nbAudioTrack,
             case WAV_OPUS:
                 break;
             default:
-                GUI_Error_HIG("Webm","Unsupported Audio.\nOnly VP8/VP9 Video and Vorbis/Opus audio supported");
+                GUI_Error_HIG("Webm","Unsupported Audio.\nOnly VP8/VP9 video and Vorbis/Opus audio supported");
                 return false;
         }
     }

--- a/avidemux_plugins/ADM_videoEncoder/x264/ADM_x264Setup.cpp
+++ b/avidemux_plugins/ADM_videoEncoder/x264/ADM_x264Setup.cpp
@@ -179,7 +179,7 @@ bool x264Encoder::setup(void)
                         param.rc.f_rf_constant = 0;
                         break;
         default:
-                        GUI_Error_HIG("Not coded","this mode has notbeen implemented\n");
+                        GUI_Error_HIG("Not coded","this mode has not been implemented\n");
                         return false;
                         break;
 

--- a/avidemux_plugins/ADM_videoEncoder/x265/ADM_x265Setup.cpp
+++ b/avidemux_plugins/ADM_videoEncoder/x265/ADM_x265Setup.cpp
@@ -155,7 +155,7 @@ bool x265Encoder::setup(void)
                         param.rc.rfConstant = 0;
                         break;
         default:
-                        GUI_Error_HIG("Not coded","this mode has notbeen implemented\n");
+                        GUI_Error_HIG("Not coded","this mode has not been implemented\n");
                         return false;
                         break;
 

--- a/myOwnPlugins/muxer/muxerLmkvAudio.cpp
+++ b/myOwnPlugins/muxer/muxerLmkvAudio.cpp
@@ -82,7 +82,7 @@ bool muxerMp4v2::addAc3(int index, WAVHeader *header)
                 case 6: acmod=7;lfe=1;break;
                 default: 
                         {
-                                  GUI_Error_HIG("","Invalid number of channel for AC3");
+                                  GUI_Error_HIG("","Invalid number of channels for AC3");
                                   return false;
                         }
         }


### PR DESCRIPTION
Fix typos and improve consistency of some error messages.

I have tried to avoid changing translatable strings where possible.