### PR TITLE
Explicitly cast to unsigned int

### DIFF
--- a/avidemux_plugins/ADM_videoEncoder/x264/qt4/Q_x264.cpp
+++ b/avidemux_plugins/ADM_videoEncoder/x264/qt4/Q_x264.cpp
@@ -38,7 +38,7 @@ typedef struct
 }idcToken;
 
 static const idcToken listOfIdc[]={
-        {-1,"Auto"},
+        {(unsigned int)-1,"Auto"},
         {10,"1"},
         {11,"1.1"},
         {12,"1.2"},

--- a/avidemux_plugins/ADM_videoEncoder/x265/qt4/Q_x265.cpp
+++ b/avidemux_plugins/ADM_videoEncoder/x265/qt4/Q_x265.cpp
@@ -38,7 +38,7 @@ typedef struct
 }idcToken;
 
 static const idcToken listOfIdc[]={
-        {-1,"Auto"},
+        {(unsigned int)-1,"Auto"},
         {10,"1"},
         {20,"2"},
         {21,"2.1"},


### PR DESCRIPTION
gcc complains again about narrowing conversion