### PR TITLE
Remove (now) unused "tmp" var.

### DIFF
--- a/avidemux_core/ADM_coreUtils/src/ADM_last.cpp
+++ b/avidemux_core/ADM_coreUtils/src/ADM_last.cpp
@@ -32,7 +32,6 @@ static void internalSetFolder(options tag,const std::string &folder)
  */
 static void internalGetFolder(options tag,  std::string &folder)
 {
-    std::string tmp;
     if (!prefs->get(tag, folder))
     {
         ADM_warning("Cannot set last Read folder for %s\n",folder.c_str());   


### PR DESCRIPTION
Leftover from https://github.com/mean00/avidemux2/commit/7c55704afc2f564437a3a283d458743423bd4a86.

(Trivial. Untested.)