### PR TITLE
[Editor] Do not try to append from empty clipboard

### DIFF
--- a/avidemux/common/ADM_editor/src/ADM_segment.cpp
+++ b/avidemux/common/ADM_editor/src/ADM_segment.cpp
@@ -946,6 +946,11 @@ bool        ADM_EditorSegment::pasteFromClipBoard(uint64_t currentTime)
  */
 bool ADM_EditorSegment::appendFromClipBoard(void)
 {
+    if(!clipboard.size())
+    {
+        ADM_info("The clipboard is empty, nothing to do\n");
+        return true;
+    }
     ADM_info("Appending from clipboard\n");
     ListOfSegments tmp=segments;
     for(int i=0;i<clipboard.size();i++) segments.push_back(clipboard[i]);


### PR DESCRIPTION
I realized too late that ADM_EditorSegment::appendFromClipBoard could use the same shortcut if the clipboard is empty, just for the sake of economy. Now as a formal push request.