### PR TITLE
[Editor][UI] Add unified undo/redo for segments and markers

### DIFF
--- a/avidemux/common/ADM_commonUI/myOwnMenu.h
+++ b/avidemux/common/ADM_commonUI/myOwnMenu.h
@@ -51,6 +51,7 @@ std::vector<MenuEntry> myMenuFile(_myMenuFile, _myMenuFile + sizeof(_myMenuFile)
 
 static const MenuEntry _myMenuEdit[] = {
             {MENU_ACTION,QT_TRANSLATE_NOOP("adm","Undo"),               NULL,ACT_Undo       ,NULL,"Ctrl+Z"},
+            {MENU_ACTION,QT_TRANSLATE_NOOP("adm","Redo"),               NULL,ACT_Redo       ,NULL,"Ctrl+Y"},
             {MENU_ACTION,QT_TRANSLATE_NOOP("adm","Reset Edit"),         NULL,ACT_ResetSegments,NULL,NULL},
             {MENU_ACTION,QT_TRANSLATE_NOOP("adm","Cut"),                NULL,ACT_Cut        ,NULL,"Ctrl+X"},
             {MENU_ACTION,QT_TRANSLATE_NOOP("adm","Copy"),               NULL,ACT_Copy       ,NULL,"Ctrl+C"},

--- a/avidemux/common/ADM_editor/include/ADM_edit.hxx
+++ b/avidemux/common/ADM_editor/include/ADM_edit.hxx
@@ -192,10 +192,6 @@ protected:
                                 ADM_Composer();
 virtual                         ~ADM_Composer();
                     void        clean( void );
-                    bool        undo(void)
-                                {
-                                    return _segments.undo();
-                                }
                     uint8_t     resetSeg( void );
                     bool        copyToClipBoard(uint64_t startTime, uint64_t endTime);
                     bool        pasteFromClipBoard(uint64_t currentTime);
@@ -218,7 +214,23 @@ public:
                     uint64_t    getMarkerBPts();
                     bool        setMarkerAPts(uint64_t pts);
                     bool        setMarkerBPts(uint64_t pts);
+/*********************************** Undo Queue ****************************/
+struct undoQueueElem
+{
+    ListOfSegments segm;
+    uint64_t markerA;
+    uint64_t markerB;
+};
+
+typedef std::vector <undoQueueElem> ListOfUndoQueueElements;
+
+protected:
+                    ListOfUndoQueueElements undoQueue;
 public:
+                    bool        addToUndoQueue(void);
+                    bool        undo(void);
+                    bool        redo(void);
+                    bool        clearUndoQueue(void);
 /************************************ Public API ***************************/
 public:
                     uint64_t    getLastKeyFramePts(void);

--- a/avidemux/common/ADM_editor/include/ADM_segment.h
+++ b/avidemux/common/ADM_editor/include/ADM_segment.h
@@ -17,7 +17,6 @@
 #ifndef ADM_SEGMENT_H
 #define ADM_SEGMENT_H
 #include <vector>
-#include <list>
 class ADM_audioStream;
 class ADM_Audiocodec;
 class decoders;
@@ -144,7 +143,6 @@ class ADM_EditorSegment
 protected:
         ListOfSegments segments;
         ListOfSegments clipboard;
-        std::list <ListOfSegments> undoSegments;
         ListOfVideos   videos;
         bool           updateStartTime(void);
 
@@ -162,7 +160,6 @@ public:
             bool        updateRefVideo(void);
             bool        deleteAll(void);
 
-            bool        undo(void);
             bool        resetSegment(void);
             bool        deleteSegments(void);
             bool        addSegment(_SEGMENT *seg);
@@ -175,6 +172,9 @@ public:
 
             _SEGMENT    *getSegment(int i);
             int         getNbSegments(void);
+
+            ListOfSegments getSegments(void);
+            bool        setSegments(ListOfSegments segm);
 
             uint64_t    getTotalDuration(void);
             uint32_t    getNbFrames(void);

--- a/avidemux/common/ADM_editor/src/ADM_segment.cpp
+++ b/avidemux/common/ADM_editor/src/ADM_segment.cpp
@@ -170,8 +170,6 @@ bool        ADM_EditorSegment::addReferenceVideo(_VIDEOS *ref)
             ref->firstFramePts=pts;
         }
 
-    if(!segments.empty()) undoSegments.push_back(segments);
-
     segments.push_back(seg);
     videos.push_back(*ref);
     updateStartTime();
@@ -185,17 +183,15 @@ bool        ADM_EditorSegment::deleteSegments()
 {
     ADM_info("Clearing a new segment\n");
     segments.clear();
-    undoSegments.clear();
     return true;
 }
 /**
-    \fn deleteSegments
-    \brief Empty the segments list
+    \fn addSegment
+    \brief Add a segment to the segments list
 */
 bool        ADM_EditorSegment::addSegment(_SEGMENT *seg)
 {
     ADM_info("Adding a new segment\n");
-    undoSegments.push_back(segments);
     segments.push_back(*seg);
     updateStartTime();
     return true;
@@ -253,21 +249,6 @@ bool ADM_EditorSegment::deleteAll (void)
     clipboard.clear();
     videos.clear();
     segments.clear();
-    undoSegments.clear();
-    return true;
-}
-
-
-/**
-    \fn undo
-    \brief
-*/
-bool        ADM_EditorSegment::undo(void)
-{
-    if(undoSegments.empty()) return false;
-    segments=undoSegments.back(); 
-    undoSegments.pop_back();
-    updateStartTime();
     return true;
 }
 /**
@@ -279,7 +260,6 @@ bool        ADM_EditorSegment::resetSegment(void)
     //
     aviInfo info;
     segments.clear();
-    undoSegments.clear();
     int n=videos.size();
     for(int i=0;i<n;i++)
     {
@@ -321,6 +301,29 @@ _VIDEOS     *ADM_EditorSegment::getRefVideo(int i)
         ADM_assert(0);
     }
     return &(videos[i]);
+}
+/**
+    \fn getSegments
+    \brief getter for the list of segments
+*/
+ListOfSegments ADM_EditorSegment::getSegments(void)
+{
+    if(segments.empty()) ADM_assert(0);
+    ListOfSegments segm=segments;
+    return segm;
+}
+/**
+    \fn setSegments
+    \brief setter for the list of segments
+*/
+bool ADM_EditorSegment::setSegments(ListOfSegments segm)
+{
+    if(segm.size())
+    {
+        segments=segm;
+        return true;
+    }
+    return false;
 }
 /**
     \fn getNbRefVideo
@@ -614,7 +617,6 @@ bool        ADM_EditorSegment::removeChunk(uint64_t from, uint64_t to)
         return false;
 
     }
-    undoSegments.push_back(tmp);
     dump();
     return true;
 }
@@ -656,7 +658,6 @@ bool ADM_EditorSegment::truncateVideo(uint64_t from)
         updateStartTime();
         return false;
     }
-    undoSegments.push_back(tmp);
     dump();
     return true;
 }
@@ -934,7 +935,6 @@ bool        ADM_EditorSegment::pasteFromClipBoard(uint64_t currentTime)
     }
     segments=newSegs;
     updateStartTime();
-    undoSegments.push_back(tmp);
     dump();
     return true;
 }
@@ -955,7 +955,6 @@ bool ADM_EditorSegment::appendFromClipBoard(void)
     ListOfSegments tmp=segments;
     for(int i=0;i<clipboard.size();i++) segments.push_back(clipboard[i]);
     updateStartTime();
-    undoSegments.push_back(tmp);
     dump();
     return true;
 }

--- a/avidemux/common/ADM_editor/src/CMakeLists.txt
+++ b/avidemux/common/ADM_editor/src/CMakeLists.txt
@@ -15,6 +15,7 @@ utils/ADM_editIface.cpp
 utils/ADM_edScriptGenerator.cpp
 utils/ADM_edFrameType.cpp
 utils/ADM_edCache.cpp
+utils/ADM_edUndoQueue.cpp
 audio/ADM_edEditableAudioTrack.cpp
 audio/ADM_edPoolOfAudioTracks.cpp
 audio/ADM_edActiveAudioTracks.cpp

--- a/avidemux/common/ADM_editor/src/utils/ADM_edUndoQueue.cpp
+++ b/avidemux/common/ADM_editor/src/utils/ADM_edUndoQueue.cpp
@@ -1,0 +1,120 @@
+/** *************************************************************************
+     \file       ADM_edUndoQueue.cpp
+     \brief      Handle Undo
+
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "ADM_cpp.h"
+#include "ADM_default.h"
+#include "ADM_segment.h"
+#include "ADM_edit.hxx"
+
+static const uint8_t maxUndoSteps=50;
+uint32_t _cnt; // track the nb of performed undo steps for redo
+
+/**
+    \fn addToUndoQueue
+    \brief stores the segment layout and markers in the undo queue
+*/
+
+bool ADM_Composer::addToUndoQueue(void)
+{
+    // truncate the dead branch first if we add a new element to the undo queue after _cnt-1 undo steps
+    if(_cnt>1 && undoQueue.size()>1)
+    {
+        for(uint32_t i=0;i<_cnt;i++)
+        {
+            undoQueue.pop_back();
+        }
+        ADM_info("Deleted last %d elements from the undo queue\n",_cnt);
+    }
+    // now populate the new element...
+    undoQueueElem rec;
+    uint64_t a=getMarkerAPts();
+    uint64_t b=getMarkerBPts();
+    rec.segm=_segments.getSegments();
+    rec.markerA=a;
+    rec.markerB=b;
+    // ...do some housekeeping...
+    uint32_t m=maxUndoSteps;
+    if(m<10) m=10; // less than 10 undo steps is a bad idea, ignore the limit then
+    uint32_t nb=undoQueue.size();
+    if(nb>m)
+    {
+        // erase the oldest records if the limit is exceeded and create space for a new one
+        undoQueue.erase(undoQueue.begin(),undoQueue.begin()+nb-m+1);
+    }
+    // ...and store the new element in the queue
+    undoQueue.push_back(rec);
+    ADM_info("The undo queue has now %d element(s)\n",undoQueue.size());
+    _cnt=0; // redo should not be available after a new undo-able action has been performed
+    return true;
+}
+
+/**
+    \fn undo
+    \brief restores the last recorded state of segments and markers
+*/
+
+bool ADM_Composer::undo(void)
+{
+    if(undoQueue.empty() || undoQueue.size()<_cnt+1)
+    {
+        ADM_info("The undo queue is empty, nothing to do\n");
+        return false;
+    }
+    if(!_cnt) // no undo steps performed yet, thus we don't have the current state in the undo queue
+    {
+        // store the current state in the queue and bump the tracker
+        // to account for the queue becoming one element longer
+        addToUndoQueue();
+        _cnt=1;
+    }
+    undoQueueElem rec=undoQueue.at(undoQueue.size()-_cnt-1);
+    ADM_info("Restoring the state recorded in the element %d starting with 1 of %d\n",undoQueue.size()-_cnt,undoQueue.size());
+    _segments.setSegments(rec.segm);
+    setMarkerAPts(rec.markerA);
+    setMarkerBPts(rec.markerB);
+    _cnt++;
+    return true;
+}
+
+/**
+    \fn redo
+    \brief reinstates the last undone state of segments and markers
+*/
+
+bool ADM_Composer::redo(void)
+{
+    if(_cnt<2 || undoQueue.size()<_cnt) // _cnt=2 once the first undo operation has been performed
+    {
+        ADM_info("The redo queue is empty, cannot perform redo\n");
+        return false;
+    }
+    undoQueueElem rec=undoQueue.at(undoQueue.size()-_cnt+1);
+    ADM_info("Restoring the state recorded in the element %d starting with 1 of %d\n",undoQueue.size()-_cnt+2,undoQueue.size());
+    _segments.setSegments(rec.segm);
+    setMarkerAPts(rec.markerA);
+    setMarkerBPts(rec.markerB);
+    _cnt--;
+    return true;
+}
+
+/**
+    \fn clearUndoQueue
+*/
+
+bool ADM_Composer::clearUndoQueue(void)
+{
+    undoQueue.clear();
+    return true;
+}
+//EOF

--- a/avidemux/common/gui_action.names
+++ b/avidemux/common/gui_action.names
@@ -73,6 +73,7 @@ ACT(Cut)
 ACT(Paste)
 ACT(Delete)
 ACT(Undo)
+ACT(Redo)
 ACT(ResetSegments)
 
 // Misc conf


### PR DESCRIPTION
My apologies for being impatient. This patch implements a unified undo/redo queue both for segments and markers, moving the undo functionality from segment management one level higher into the composer and adding a "Redo" item with Ctrl+Y shortcut to the "Edit" menu. The new functions `ADM_Composer::addToUndoQueu`, `ADM_Composer::undo`, `ADM_Composer::redo` and `ADM_Composer::clearUndoQueue` get called now directly from UI actions.

A few notes: Undoing or redoing a cut/delete/paste operation bypasses the position adjustment logic implemented in ACT_Cut/Delete/Paste. This is a design limitation. Ideally, the undo queue would become action-aware and the implementation would provide a clue for GUI to disable not applicable options.

While I can't tell from my zero level of experience if the patch suffers from bad coding practices, it has been quite extensively tested and WFM.
