### PR TITLE
[x264/Qt][x265/Qt] Add translatable default none tuning

### DIFF
--- a/avidemux_plugins/ADM_videoEncoder/x264/qt4/Q_x264.cpp
+++ b/avidemux_plugins/ADM_videoEncoder/x264/qt4/Q_x264.cpp
@@ -85,7 +85,7 @@ static const aspectRatio predefinedARs[]={
 static const char* listOfPresets[] = { "ultrafast", "superfast", "veryfast", "faster", "fast", "medium", "slow", "slower", "veryslow", "placebo" };
 #define NB_PRESET sizeof(listOfPresets)/sizeof(char*)
 
-static const char* listOfTunings[] = { "film", "animation", "grain", "stillimage", "psnr", "ssim" };
+static const char* listOfTunings[] = { "", "film", "animation", "grain", "stillimage", "psnr", "ssim" };
 #define NB_TUNE sizeof(listOfTunings)/sizeof(char*)
 
 static const char* listOfProfiles[] = { "baseline", "main", "high", "high10", "high422", "high444" };
@@ -171,7 +171,10 @@ x264Dialog::x264Dialog(QWidget *parent, void *param) : QDialog(parent)
         tunings->clear();
         for(int i=0;i<NB_TUNE;i++)
         {
-            tunings->addItem(QString(listOfTunings[i]));
+            const char* _tn=listOfTunings[i];
+            if(_tn=="")
+                _tn=QT_TRANSLATE_NOOP("x264","none");
+            tunings->addItem(QString(_tn));
         }
 
         QComboBox* profiles=ui.profileComboBox;

--- a/avidemux_plugins/ADM_videoEncoder/x264/qt4/Q_x264.cpp
+++ b/avidemux_plugins/ADM_videoEncoder/x264/qt4/Q_x264.cpp
@@ -85,6 +85,7 @@ static const aspectRatio predefinedARs[]={
 static const char* listOfPresets[] = { "ultrafast", "superfast", "veryfast", "faster", "fast", "medium", "slow", "slower", "veryslow", "placebo" };
 #define NB_PRESET sizeof(listOfPresets)/sizeof(char*)
 
+// Empty string "" as tuning means no tuning. This is the default.
 static const char* listOfTunings[] = { "", "film", "animation", "grain", "stillimage", "psnr", "ssim" };
 #define NB_TUNE sizeof(listOfTunings)/sizeof(char*)
 

--- a/avidemux_plugins/ADM_videoEncoder/x264/qt4/Q_x264.cpp
+++ b/avidemux_plugins/ADM_videoEncoder/x264/qt4/Q_x264.cpp
@@ -172,6 +172,8 @@ x264Dialog::x264Dialog(QWidget *parent, void *param) : QDialog(parent)
         for(int i=0;i<NB_TUNE;i++)
         {
             const char* _tn=listOfTunings[i];
+            // we pass an empty string to the encoder in order to disable tuning,
+            // but want to show a descriptive label to the user
             if(_tn=="")
                 _tn=QT_TRANSLATE_NOOP("x264","none");
             tunings->addItem(QString(_tn));

--- a/avidemux_plugins/ADM_videoEncoder/x265/qt4/Q_x265.cpp
+++ b/avidemux_plugins/ADM_videoEncoder/x265/qt4/Q_x265.cpp
@@ -177,6 +177,8 @@ x265Dialog::x265Dialog(QWidget *parent, void *param) : QDialog(parent)
         tunings->clear();
         for(int i=0;i<NB_TUNE;i++)
         {
+            // we pass an empty string to the encoder in order to disable tuning,
+            // but want to show a descriptive label to the user
             const char* _tn=listOfTunings[i];
             if(_tn=="")
                 _tn=QT_TRANSLATE_NOOP("x265","none");

--- a/avidemux_plugins/ADM_videoEncoder/x265/qt4/Q_x265.cpp
+++ b/avidemux_plugins/ADM_videoEncoder/x265/qt4/Q_x265.cpp
@@ -82,6 +82,7 @@ static const aspectRatio predefinedARs[]={
 static const char* listOfPresets[] = { "ultrafast", "superfast", "veryfast", "faster", "fast", "medium", "slow", "slower", "veryslow", "placebo" };
 #define NB_PRESET sizeof(listOfPresets)/sizeof(char*)
 
+// Empty string "" as tuning means no tuning. This is the default.
 static const char* listOfTunings[] = { "", "psnr", "ssim", "grain", "zerolatency", "fastdecode" };
 #define NB_TUNE sizeof(listOfTunings)/sizeof(char*)
 

--- a/avidemux_plugins/ADM_videoEncoder/x265/qt4/Q_x265.cpp
+++ b/avidemux_plugins/ADM_videoEncoder/x265/qt4/Q_x265.cpp
@@ -82,7 +82,7 @@ static const aspectRatio predefinedARs[]={
 static const char* listOfPresets[] = { "ultrafast", "superfast", "veryfast", "faster", "fast", "medium", "slow", "slower", "veryslow", "placebo" };
 #define NB_PRESET sizeof(listOfPresets)/sizeof(char*)
 
-static const char* listOfTunings[] = { "psnr", "ssim", "zerolatency", "fastdecode" };
+static const char* listOfTunings[] = { "", "psnr", "ssim", "grain", "zerolatency", "fastdecode" };
 #define NB_TUNE sizeof(listOfTunings)/sizeof(char*)
 
 static const char* listOfProfiles[] = { "main", "main10", "mainstillpicture" };
@@ -177,7 +177,10 @@ x265Dialog::x265Dialog(QWidget *parent, void *param) : QDialog(parent)
         tunings->clear();
         for(int i=0;i<NB_TUNE;i++)
         {
-            tunings->addItem(QString(listOfTunings[i]));
+            const char* _tn=listOfTunings[i];
+            if(_tn=="")
+                _tn=QT_TRANSLATE_NOOP("x265","none");
+            tunings->addItem(QString(_tn));
         }
 
         QComboBox* profiles=ui.profileComboBox;


### PR DESCRIPTION
This patch adds null/none tuning as the default tuning for x264 and x265 encoders if the advanced configuration is disabled and makes the label "none" translatable. Furthermore, it adds `grain` to the `ListOfTunings` array for x265.

This is basically [[x265/Qt] Add none preset (eumagga0x2a)](https://github.com/mean00/avidemux2/commit/6bb59711f290291c532bd60f37513e3b04d763e3), but finally done right (hopefully).
