### PR TITLE
[UI] Work around tabbing order issues in the 'Display' tab of the preferences dialog

### DIFF
--- a/avidemux/common/ADM_commonUI/DIA_prefs.cpp
+++ b/avidemux/common/ADM_commonUI/DIA_prefs.cpp
@@ -448,12 +448,21 @@ std::string currentSdlDriver=getSdlDriverName();
         /* Display */
         diaElemToggle togDisplayRefreshCap(&refreshCapEnabled,QT_TRANSLATE_NOOP("adm","_Limit Refresh Rate"));
         diaElemUInteger displayRefreshCap(&refreshCapValue,QT_TRANSLATE_NOOP("adm","Refresh Rate Cap (ms)"),10,1000);
+        diaElemFrame frameRC(QT_TRANSLATE_NOOP("adm","GUI Rendering Options")); // a hack to fix tabbing order
 
+        // Packing the following elements into frameRC rectifies otherwise wrong tabbing order:
+        // framePP got constructed before the refresh rate spinbox, but after the display refresh
+        // toggle resulting in a tabbing order 1-6-7-2-3-4-5-8, counting elements from top to bottom.
+        // With this extra frame we get 1-2-3-4-5-6-7-8 (video mode, hor. deblocking, vert. delocking,
+        // deringing, deringing strength, OpenGL toggle, refr. rate cap toggle, refr. rate spinbox).
+        frameRC.swallow(&useOpenGl);
+        frameRC.swallow(&togDisplayRefreshCap);
+        frameRC.swallow(&displayRefreshCap);
 
 #ifdef USE_SDL
-        diaElem *diaVideo[]={&menuVideoMode,sdlMenu,&framePP,&useOpenGl,&togDisplayRefreshCap,&displayRefreshCap};
+        diaElem *diaVideo[]={&menuVideoMode,sdlMenu,&framePP,&frameRC};
 #else
-         diaElem *diaVideo[]={&menuVideoMode,&framePP,&useOpenGl,&togDisplayRefreshCap,&displayRefreshCap};
+        diaElem *diaVideo[]={&menuVideoMode,&framePP,&frameRC};
 #endif
         diaElemTabs tabVideo(QT_TRANSLATE_NOOP("adm","Display"),sizeof(diaVideo)/sizeof(diaElem *),(diaElem **)diaVideo);
         /* HW accel */


### PR DESCRIPTION
This patch fixes or rather works around the keyboard navigation issue described in [Strange tab order in Edit / Prefences / Display](http://avidemux.org/smif/index.php/topic,16972.0.html). It seems that there is currently no way to set tabbing order of dialog elements unambiguously, which means that elements get ordered in "first come, first served" manner. Oddly enough, this doesn't lead to problems except of in the Display tab of the preferences dialog, where the tabbing order is very wrong.

The patch combines three top-level elements into a second frame, ordered below the first one. This is enough to correct the tabbing order, according to my testing, and looks quit similar to the current design.

The title of the additional frame, "GUI Rendering Options", seems to match the meaning of the options below, but I don't insist on it. An empty string as title results in a big gap between elements which looks odd though.

An alternative to a second frame would be moving framePP to the end of the list, but this doesn't fit the logic of the dialog well, IMVHO.