### PR TITLE
[Demuxer/MpegPS] Do not round up the height to a multiple of 16

### DIFF
--- a/avidemux_plugins/ADM_demuxers/MpegPS/ADM_psIndex.cpp
+++ b/avidemux_plugins/ADM_demuxers/MpegPS/ADM_psIndex.cpp
@@ -259,7 +259,7 @@ bool bAppend=false;
                           video.interlaced=0; // how to detect ?
                           video.w=val>>20;
                           video.w=((video.w+15)&~15);
-                          video.h= (((val>>8) & 0xfff)+15)& ~15;
+                          video.h=((val>>8) & 0xfff);
 
                           video.ar = (val >> 4) & 0xf;
 


### PR DESCRIPTION
Apply the same logic as in `avidemux_plugins/ADM_demuxers/MpegTS/ADM_tsIndexMpeg2.cpp:123` and don't round up the height of the video to a multiple of 16.

Reference: [MPEG-2 resolution 1920x1080 opened and encoded with 1920x1088](http://avidemux.org/smif/index.php/topic,17258.0.html).