### PR TITLE
[Qt] Restore correct window state upon finishing encoding while minimized to notification area

### DIFF
--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
@@ -105,6 +105,7 @@ extern bool A_loadDefaultSettings(void);;
 extern void ADM_ExitCleanup(void);
 
 static bool uiRunning=false;
+static bool uiIsMaximized=false;
 
 #define WIDGET(x)  (((MainWindow *)QuiMainWindows)->ui.x)
 
@@ -1501,6 +1502,7 @@ bool UI_hasOpenGl(void)
 */
 void UI_iconify( void )
 {
+    uiIsMaximized=QuiMainWindows->isMaximized();
     QuiMainWindows->hide();
 
 }
@@ -1509,11 +1511,16 @@ void UI_iconify( void )
 */
 void UI_deiconify( void )
 {
-    QuiMainWindows->showNormal();
-
+    if(uiIsMaximized)
+    {
+        QuiMainWindows->showMaximized();
+    }else
+    {
+        QuiMainWindows->showNormal();
+    }
 }
 /**
-    \fn UI_deiconify
+    \fn UI_setAudioTrackCount
 */
 void UI_setAudioTrackCount( int nb )
 {


### PR DESCRIPTION
This patch fixes `UI_deiconify` to take the last window state into account instead of always trying to restore to a normal window (Avidemux window retaining the maximized state when manually restored from "tray" on Linux even without this patch must be a bug in gnome-shell or Qt).

While tested WFM on Linux, I'm pretty confident that this patch should fix the issue on Windows as well.

Reference: [Avidemux 2.6.4 - Minimize to notification area](http://avidemux.org/smif/index.php/topic,12493.0.html)