### PR TITLE
[Qt] Set the size of time display to fit the content

### DIFF
--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
@@ -418,6 +418,13 @@ MainWindow::MainWindow(const vector<IScriptEngine*>& scriptEngines) : _scriptEng
     QRegExpValidator *timeValidator = new QRegExpValidator(timeRegExp, this);
     ui.currentTime->setValidator(timeValidator);
     ui.currentTime->setInputMask("99:99:99.999");
+    // set the size of the current time display to fit the content
+    QString text=ui.currentTime->text();
+    QFontMetrics fm=ui.currentTime->fontMetrics();
+    int currentTimeWidth=fm.boundingRect(text).width()+16;
+    int currentTimeHeight=ui.currentTime->height();
+    ui.currentTime->setFixedSize(currentTimeWidth, currentTimeHeight);
+    ui.currentTime->adjustSize();
 
     //connect(ui.currentTime, SIGNAL(editingFinished()), this, SLOT(currentTimeChanged()));
 


### PR DESCRIPTION
I think I've nailed it. Though not yet tested on Windows, I'm pretty confident that this would work reliably everywhere and look good with all font sizes.

The earlier attempt [[ui/qt] bigger time display (flexible/euma)](https://github.com/mean00/avidemux2/commit/c9d2a656a6122f9dd27687a5b4d8fb7326393489) turned out to be a waste of your time, my apologies. As feared, the results didn't look good on Windows with usual tiny fonts.