### PR TITLE
[Qt] Make the time display 4px wider to avoid clipping with breeze Qt theme

### DIFF
--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
@@ -421,7 +421,7 @@ MainWindow::MainWindow(const vector<IScriptEngine*>& scriptEngines) : _scriptEng
     // set the size of the current time display to fit the content
     QString text=ui.currentTime->text();
     QFontMetrics fm=ui.currentTime->fontMetrics();
-    int currentTimeWidth=fm.boundingRect(text).width()+16;
+    int currentTimeWidth=fm.boundingRect(text).width()+20;
     int currentTimeHeight=ui.currentTime->height();
     ui.currentTime->setFixedSize(currentTimeWidth, currentTimeHeight);
     ui.currentTime->adjustSize();


### PR DESCRIPTION
This should be enough to avoid clipping with the breeze theme.