### PR TITLE
[Core/FFmpeg] Do not try to patch already patched common.mak, unbreak --rebuild option

### DIFF
--- a/cmake/admFFmpegBuild_native.cmake
+++ b/cmake/admFFmpegBuild_native.cmake
@@ -15,9 +15,10 @@ ENDIF(USE_NVENC)
 #@@
 ADM_FF_PATCH_IF_NEEDED()
 
-MESSAGE(STATUS "Patching Linux common.mak")
-patch_file("${FFMPEG_SOURCE_DIR}" "${FFMPEG_PATCH_DIR}/common.mak.diff")
-
+if (FFMPEG_PERFORM_PATCH)
+    MESSAGE(STATUS "Patching Linux common.mak")
+    patch_file("${FFMPEG_SOURCE_DIR}" "${FFMPEG_PATCH_DIR}/common.mak.diff")
+endif (FFMPEG_PERFORM_PATCH)
 
 xadd(--enable-pthreads)
 


### PR DESCRIPTION
As of [[core/ffmpeg] fix patching ](https://github.com/mean00/avidemux2/commit/6df6ec6d4e0c1d951df3b1748f5efd85efcbb1ef) the code in `cmake/admFFmpegBuild_native.cmake:18` tries to patch common.mak no matter what, breaking the build with --rebuild option as a result. This patch takes into account the value of the `FFMPEG_PERFORM_PATCH` env variable.