### PR TITLE
[UI/Render] Disable faulty check for remote display breaking VDPAU

### DIFF
--- a/avidemux/common/gui_main.cpp
+++ b/avidemux/common/gui_main.cpp
@@ -1578,11 +1578,13 @@ ADM_RENDER_TYPE UI_getPreferredRender(void)
         {
                 return RENDER_GTK;
         }
+#if 0
         if(strcmp(displ,":0") && strcmp(displ,":0.0"))
         {
                 printf("Looks like remote display, no Xv :%s\n",displ);
                 return RENDER_GTK;
         }
+#endif
 #endif
 
         if(prefs->get(VIDEODEVICE,&renderI)!=RC_OK)


### PR DESCRIPTION
On Fedora and probably other distributions with GNOME and gdm as display manager the default value for $DESKTOP is `:1` for the local display, thus resulting in hardware accelerated video output in Avidemux wrongly disabled. Let us please disable the check for `$DISPLAY` == `:0` which does much more harm than good.