### PR TITLE
[Build/FFmpeg] Fix FFmpeg checkout from git as fallback and archiving

### DIFF
--- a/cmake/admFFmpegBuild_helpers.cmake
+++ b/cmake/admFFmpegBuild_helpers.cmake
@@ -55,6 +55,10 @@ MACRO(ADM_FF_SET_DEFAULT)
     include(admFFmpegUtil)
     include(admFFmpegPrepareTar)
 
+    if (NOT FFMPEG_PREPARED)
+        include(admFFmpegPrepareGit)
+    endif (NOT FFMPEG_PREPARED)
+
 ENDMACRO(ADM_FF_SET_DEFAULT)
 
 

--- a/cmake/admFFmpegPrepareGit.cmake
+++ b/cmake/admFFmpegPrepareGit.cmake
@@ -8,10 +8,10 @@ endif (NOT VERBOSE)
 # Checkout FFmpeg source and patch it
 if (NOT EXISTS  "${FFMPEG_SOURCE_DIR}/${FFMPEG_VERSION}")
 	message(STATUS "Checking out FFmpeg from git repository")
-	execute_process(COMMAND ${GIT_EXECUTABLE} clone --depth 20 git://git.videolan.org/ffmpeg.git  "${FFMPEG_SOURCE_DIR}"
+	execute_process(COMMAND ${GIT_EXECUTABLE} clone git://git.videolan.org/ffmpeg.git  "${FFMPEG_SOURCE_DIR}"
 					${ffmpegGitOutput})
 	MESSAGE(STATUS "Going to revision ${FFMPEG_VERSION}")
-	execute_process(COMMAND ${GIT_EXECUTABLE} checkout   ${FFMPEG_VERSION}
+	execute_process(COMMAND ${GIT_EXECUTABLE} checkout tags/n${FFMPEG_VERSION} -b ${FFMPEG_VERSION}
 					WORKING_DIRECTORY "${FFMPEG_SOURCE_DIR}"
 					${ffmpegSvnOutput})
 	execute_process(COMMAND touch "${FFMPEG_SOURCE_DIR}/${FFMPEG_VERSION}")
@@ -20,7 +20,6 @@ if (NOT EXISTS  "${FFMPEG_SOURCE_DIR}/${FFMPEG_VERSION}")
 	execute_process(COMMAND ${TAR_EXECUTABLE} czf  "${FFMPEG_ROOT_DIR}/${FFMPEG_SOURCE_ARCHIVE}" --exclude .git source
 				WORKING_DIRECTORY "${FFMPEG_BASE_DIR}"
 				)
-	set(FFMPEG_PERFORM_PATCH 1)
 	set(FFMPEG_PERFORM_PATCH 1)
 endif (NOT EXISTS  "${FFMPEG_SOURCE_DIR}/${FFMPEG_VERSION}")
 

--- a/cmake/admFFmpegPrepareGit.cmake
+++ b/cmake/admFFmpegPrepareGit.cmake
@@ -1,4 +1,5 @@
 find_package(Git)
+find_package(Tar)
 
 if (NOT VERBOSE)
 	set(ffmpegGitOutput OUTPUT_VARIABLE FFMPEG_GIT_OUTPUT)
@@ -8,7 +9,7 @@ endif (NOT VERBOSE)
 # Checkout FFmpeg source and patch it
 if (NOT EXISTS  "${FFMPEG_SOURCE_DIR}/${FFMPEG_VERSION}")
 	message(STATUS "Checking out FFmpeg from git repository")
-	execute_process(COMMAND ${GIT_EXECUTABLE} clone git://git.videolan.org/ffmpeg.git  "${FFMPEG_SOURCE_DIR}"
+	execute_process(COMMAND ${GIT_EXECUTABLE} clone git://git.videolan.org/ffmpeg.git "${FFMPEG_SOURCE_DIR}"
 					${ffmpegGitOutput})
 	MESSAGE(STATUS "Going to revision ${FFMPEG_VERSION}")
 	execute_process(COMMAND ${GIT_EXECUTABLE} checkout tags/n${FFMPEG_VERSION} -b ${FFMPEG_VERSION}
@@ -16,8 +17,8 @@ if (NOT EXISTS  "${FFMPEG_SOURCE_DIR}/${FFMPEG_VERSION}")
 					${ffmpegSvnOutput})
 	execute_process(COMMAND touch "${FFMPEG_SOURCE_DIR}/${FFMPEG_VERSION}")
 	MESSAGE(STATUS "Archiving ffmpeg ${FFMPEG_VERSION}")
-	MESSAGE(STATUS "${TAR_EXECUTABLE}  --exclude .git czf ${FFMPEG_ROOT_DIR}/${FFMPEG_SOURCE_ARCHIVE} ffmpeg, DIR=${FFMPEG_BASE_DIR}")
-	execute_process(COMMAND ${TAR_EXECUTABLE} czf  "${FFMPEG_ROOT_DIR}/${FFMPEG_SOURCE_ARCHIVE}" --exclude .git source
+	MESSAGE(STATUS "${TAR_EXECUTABLE} cjf ${FFMPEG_ROOT_DIR}/${FFMPEG_SOURCE_ARCHIVE} --exclude .git source; DIR=${FFMPEG_BASE_DIR}")
+	execute_process(COMMAND ${TAR_EXECUTABLE} cjf "${FFMPEG_ROOT_DIR}/${FFMPEG_SOURCE_ARCHIVE}" --exclude .git source
 				WORKING_DIRECTORY "${FFMPEG_BASE_DIR}"
 				)
 	set(FFMPEG_PERFORM_PATCH 1)


### PR DESCRIPTION
I wonder if it is just the videolan.org git mirror which is so unbearably slow, maybe switching to ffmpeg.org would work better if this feature ever gets used.

The archiving part is untested, unfortunately, but should work, hopefully. It can't work without the second patch, obviously, as `TAR_EXECUTABLE` remains unset then.