### PR TITLE
[Pref] Return false if loading config fails, avoid selecting dummy audio device in this case

### DIFF
--- a/avidemux_core/ADM_coreUtils/src/prefs.cpp
+++ b/avidemux_core/ADM_coreUtils/src/prefs.cpp
@@ -187,7 +187,7 @@ bool preferences::load()
         return true;
     }
     ADM_warning("An error happened while loading config\n");
-    return true;
+    return false;
 }
 
 /**


### PR DESCRIPTION
`preferences::load` returning `true` on error deserializing prefs struct led to "Dummy" audio device being selected if new preference settings were added or old ones removed, because `setPrefsDefault()` was not run within `startAvidemux` function in `avidemux/common/main.cpp` in this case.

Reference: [No sound during playback of any video file using latest version of Avidemux](http://avidemux.org/smif/index.php/topic,17290.0.html)