### PR TITLE
[x265] Use utf8 for filenames on Windows too

### DIFF
--- a/avidemux_plugins/ADM_videoEncoder/x265/CMakeLists.txt
+++ b/avidemux_plugins/ADM_videoEncoder/x265/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 INCLUDE(ve_plugin)
 INCLUDE(ve_settings_plugin)
-
+ADD_DEFINITIONS(-DX265_USE_UTF8=1)
 SET(x265_SRCS 
         ADM_x265.cpp
         ADM_x265Plugin.cpp


### PR DESCRIPTION
This fixes 2-pass encoding in HEVC failing on Windows when the specified filename contains diacritics or other non-ASCII characters. The patch is exactly the same solution as used in the x264 encoder.

Reference: [x265 pass 2 failure](http://avidemux.org/smif/index.php/topic,17296.0.html)