### PR TITLE
[core/prefs] Accept too long or incomplete partial parameter lists

### DIFF
--- a/avidemux_core/ADM_coreUtils/src/ADM_paramList.cpp
+++ b/avidemux_core/ADM_coreUtils/src/ADM_paramList.cpp
@@ -258,7 +258,7 @@ bool ADM_paramValidatePartialList(CONFcouple *couples, const    ADM_paramList *p
     int p=XgetParamSize(params);
     if(n>p)
     {
-        ADM_warning("Too many parameters in partial list");
+        ADM_warning("Too many parameters in partial list\n");
         return false;
     }
     int found=0;
@@ -389,17 +389,19 @@ bool ADM_paramLoad(CONFcouple *couples, const ADM_paramList *params,void *s)
 
 }
 /**
-    \fn ADM_paramLoad
+    \fn ADM_paramLoadPartial
     \brief Load a structure from a list of confCouple, accept partial fields
 */
 
 bool ADM_paramLoadPartial(CONFcouple *couples, const ADM_paramList *params,void *s)
 {
-   if(false==ADM_paramValidatePartialList(couples,params)) return false;
+   // don't reject too long or incomplete param lists, this does more harm than good
+   // e.g. on version update, but warnings are nice
+   ADM_paramValidatePartialList(couples,params);
    return ADM_paramLoadInternal(true,couples,params,s);
 }
 /**
-    \fn ADM_paramLoad
+    \fn ADM_paramSave
     \brief Save a structure to a list of confCouple
 */
 bool ADM_paramSave(CONFcouple **couples, const ADM_paramList *params,void *s)


### PR DESCRIPTION
Ignoring the return value of ADM_paramValidatePartialList prevents Avidemux from unnecessarily discarding configuration on version update. According to my testing with added or removed entries in config3 this is reasonably safe (the only crash I experienced – unrecoverable without fixing or deleting the config3 file manually  – happens independently of this patch). Type validation is provided to some degree within the `ADM_paramLoadInternal` function.