### PR TITLE
[Qt] Align the mute button and the volume slider, avoid clipping

### DIFF
--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/gui2.ui
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/gui2.ui
@@ -1603,8 +1603,8 @@
    </attribute>
    <widget class="QWidget" name="dockWidgetContents_5">
     <layout class="QVBoxLayout" name="verticalLayout_4">
-     <property name="topMargin">
-      <number>0</number>
+     <property name="alignment">
+      <set>Qt::AlignHCenter</set>
      </property>
      <item>
       <widget class="QToolButton" name="toolButtonAudioToggle">
@@ -1619,7 +1619,7 @@
        </property>
        <property name="minimumSize">
         <size>
-         <width>0</width>
+         <width>22</width>
          <height>22</height>
         </size>
        </property>
@@ -1639,22 +1639,6 @@
       </widget>
      </item>
      <item>
-      <spacer name="verticalSpacer">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::MinimumExpanding</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
       <widget class="QSlider" name="horizontalSlider_2">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Minimum">
@@ -1664,8 +1648,8 @@
        </property>
        <property name="minimumSize">
         <size>
-         <width>0</width>
-         <height>30</height>
+         <width>22</width>
+         <height>50</height>
         </size>
        </property>
        <property name="maximum">


### PR DESCRIPTION
Currently the top edge of the mute button gets clipped with the "fusion" Qt theme, the spacer results in a much too big distance between the button and the slider and the button and the slider are not aligned:

![volume-widget-linux-as-is-fusion-theme](https://cloud.githubusercontent.com/assets/23018873/21255607/3f5ca8fc-c36d-11e6-9a47-d5f80fcced95.png)

This patch centers the button and the slider horizontally and gets rid of the spacer and zero top margin for the button, avoiding clipping:

![volume-widget-linux-patched-fusion-theme](https://cloud.githubusercontent.com/assets/23018873/21255806/7c66b494-c36e-11e6-8847-b666fa04b95e.png)

Tested WFM on Windows as well.
