### PR TITLE
[build/cmake] Fix NVENC detection and ffmpeg configure options

### DIFF
--- a/cmake/admCheckNvEnc.cmake
+++ b/cmake/admCheckNvEnc.cmake
@@ -6,8 +6,8 @@ MACRO(checkNvEnc)
 		MESSAGE(STATUS "*****************")
 
 		IF (NVENC)
-                        FIND_PATH(NVENC_INCLUDE_DIR nvEncodeAPI.h 
-		      	PATHS /usr/include/x86_64-linux-gnu) # Needed for 64 bits linux
+                        FIND_PATH(NVENC_INCLUDE_DIR nvEncodeAPI.h
+                        PATHS /usr/include /usr/include/nvenc /usr/include/x86_64-linux-gnu) # Needed for 64 bits linux
                         IF(NVENC_INCLUDE_DIR)
 				MESSAGE(STATUS " nvenc header Found ")
                                 SET(USE_NVENC True)
@@ -19,6 +19,7 @@ MACRO(checkNvEnc)
 		        SET(NVENC_CHECKED 1)
 		ENDIF (NVENC)
 
+		MESSAGE(STATUS "NVENC header found in ${NVENC_INCLUDE_DIR}")
 		MESSAGE("")
 	APPEND_SUMMARY_LIST("Video Encoder" "NVENC" "${NVENC_FOUND}")
 	ENDIF (NOT NVENC_CHECKED)

--- a/cmake/admCheckNvEnc.cmake
+++ b/cmake/admCheckNvEnc.cmake
@@ -9,7 +9,7 @@ MACRO(checkNvEnc)
                         FIND_PATH(NVENC_INCLUDE_DIR nvEncodeAPI.h
                         PATHS /usr/include /usr/include/nvenc /usr/include/x86_64-linux-gnu) # Needed for 64 bits linux
                         IF(NVENC_INCLUDE_DIR)
-				MESSAGE(STATUS " nvenc header Found ")
+				MESSAGE(STATUS " nvenc header Found in ${NVENC_INCLUDE_DIR}")
                                 SET(USE_NVENC True)
                                 SET(NVENC_FOUND 1)
                         ELSE(NVENC_INCLUDE_DIR)
@@ -19,7 +19,6 @@ MACRO(checkNvEnc)
 		        SET(NVENC_CHECKED 1)
 		ENDIF (NVENC)
 
-		MESSAGE(STATUS "NVENC header found in ${NVENC_INCLUDE_DIR}")
 		MESSAGE("")
 	APPEND_SUMMARY_LIST("Video Encoder" "NVENC" "${NVENC_FOUND}")
 	ENDIF (NOT NVENC_CHECKED)

--- a/cmake/admFFmpegBuild_native.cmake
+++ b/cmake/admFFmpegBuild_native.cmake
@@ -9,6 +9,7 @@ IF(USE_NVENC)
    SET(FFMPEG_ENCODERS ${FFMPEG_ENCODERS} nvenc)
    xadd("--enable-nonfree")
    xadd("--enable-nvenc")
+   xadd("--extra-cflags=-I${NVENC_INCLUDE_DIR}")
    set(FFMPEG_ENCODERS  ${FFMPEG_ENCODERS} nvenc_h264 nvenc_hevc)
 ENDIF(USE_NVENC)
 


### PR DESCRIPTION
This fixes NVENC detection and ffmpeg configuration during a native build on Fedora. Tested working in MXE as well.