### PR TITLE
[UI] Remove forgotten unused variable and simplify handling of pts==0 in A_jumpToTime

### DIFF
--- a/avidemux/common/gui_navigate.cpp
+++ b/avidemux/common/gui_navigate.cpp
@@ -530,12 +530,12 @@ bool GUI_infiniteForward(uint64_t pts)
 bool GUI_lastFrameBeforePts(uint64_t pts)
 {
     uint64_t pts2=pts;
-    uint64_t tmp;
     // Try to find a keyframe just before pts
     if(video_body->getPKFramePTS(&pts2))
     { // Starting from there, approach the last frame before pts
         admPreview::deferDisplay(1);
         GUI_GoToTime(pts2);
+        uint64_t tmp;
         while(pts2<pts)
         {
             tmp=pts2;

--- a/avidemux/common/gui_navigate.cpp
+++ b/avidemux/common/gui_navigate.cpp
@@ -446,7 +446,6 @@ void GUI_setCurrentFrameAndTime(uint64_t offset)
 */
 bool A_jumpToTime(uint32_t hh,uint32_t mm,uint32_t ss,uint32_t ms)
 {
-    uint64_t playpos=admPreview::getCurrentPts();
     uint64_t pts;
     pts=hh*3600+mm*60+ss;
     pts*=1000;
@@ -467,11 +466,8 @@ bool A_jumpToTime(uint32_t hh,uint32_t mm,uint32_t ss,uint32_t ms)
         if(pts>=lastpts) // if at or beyond the last frame but within the total duration
             return GUI_GoToTime(lastpts); // go to the last frame
     }
-    if(false==GUI_lastFrameBeforePts(pts)) // we are probably at the beginning of the video...
-    {
-        if(false==video_body->goToTimeVideo(pts)) // ...and there is no keyframe at pts==0
-            video_body->rewind(); // go to the first frame then
-    }
+    if(false==GUI_lastFrameBeforePts(pts)) // we are probably at the beginning of the video,
+        video_body->rewind(); // go to the first frame then
     admPreview::samePicture();
     GUI_setCurrentFrameAndTime();
     return true;


### PR DESCRIPTION
Oops, there were some editing leftovers in the last commit. Also don't try to call `goToTimeVideo` with `pts` equal zero, it spits a ton of terrifying errors if it fails, just call `rewind()`.

My apologies for the trouble.