### PR TITLE
[cosmetics] Show an uppercase string as decoder name for VDPAU

### DIFF
--- a/avidemux/common/ADM_render/GUI_vdpauRender.h
+++ b/avidemux/common/ADM_render/GUI_vdpauRender.h
@@ -34,7 +34,7 @@ class vdpauRender: public VideoRenderBase
               virtual   bool refresh(void);
               virtual   bool usingUIRedraw(void) {return false;}; // we can redraw by ourself
               virtual   ADM_HW_IMAGE getPreferedImage(void ) {return ADM_HW_VDPAU;}
-                        const char *getName() {return "Vdpau";}
+                        const char *getName() {return "VDPAU";}
 };
 
 


### PR DESCRIPTION
Displaying "VDPAU" for video output and "Vdpau" a few pixels to the right for video decoder looked a bit strange for me. Adjust the case of the latter to match the former and the convention.