### PR TITLE
[Qt] Reduce the minimum width of the selection widget

### DIFF
--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/gui2.ui
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/gui2.ui
@@ -1438,16 +1438,10 @@
    </widget>
   </widget>
   <widget class="QDockWidget" name="selectionWidget">
-   <property name="sizePolicy">
-    <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-     <horstretch>0</horstretch>
-     <verstretch>0</verstretch>
-    </sizepolicy>
-   </property>
    <property name="minimumSize">
     <size>
-     <width>192</width>
-     <height>163</height>
+     <width>160</width>
+     <height>150</height>
     </size>
    </property>
    <property name="features">


### PR DESCRIPTION
As evident from screenshots in [https://github.com/mean00/avidemux2/pull/54](https://github.com/mean00/avidemux2/pull/54), the width of the selection widget is excessive, wasting space to the left of the volume widget. With the proposed change it would look as follows with the "fusion" Qt theme (tested with "gtk" and "adwaita" as well):

![selection-widget-linux-patched-fusion-theme](https://cloud.githubusercontent.com/assets/23018873/21404185/45bf436a-c7c0-11e6-94a0-f522c7d29b3e.png)

One caveat: I can't test how it looks in HiDPI conditions, but I hope that dropping fixed width would only improve its behaviour.

edit: Actually, the patch reduces also the minimum height, which looked excessive too.
