### PR TITLE
[i18n/de/ru] Add kb accels to the audio track dialog, add a missing translation and fix agreement in i18n/ru

### DIFF
--- a/avidemux/qt4/i18n/avidemux_de.ts
+++ b/avidemux/qt4/i18n/avidemux_de.ts
@@ -4487,7 +4487,7 @@ Drop timing informations ?</source>
         <location line="+41"/>
         <location line="+41"/>
         <source>Configure</source>
-        <translation type="unfinished">Konfigurieren</translation>
+        <translation type="unfinished">&amp;Konfigurieren</translation>
     </message>
     <message>
         <source>Audio Filters</source>
@@ -4519,7 +4519,7 @@ Drop timing informations ?</source>
         <location line="+41"/>
         <location line="+41"/>
         <source>Enabled</source>
-        <translation type="unfinished">aktivieren</translation>
+        <translation type="unfinished">ak&amp;tivieren</translation>
     </message>
     <message>
         <location line="-100"/>
@@ -4527,7 +4527,7 @@ Drop timing informations ?</source>
         <location line="+41"/>
         <location line="+41"/>
         <source>Filters</source>
-        <translation type="unfinished">Filter</translation>
+        <translation type="unfinished">&amp;Filter</translation>
     </message>
 </context>
 <context>
@@ -17489,7 +17489,7 @@ Wenn dies eine mitgelieferte Konfiguration ist, wird sie nach Neustart der Anwen
     <message>
         <location line="+6"/>
         <source>Use advanced configuration</source>
-        <translation>_Erweiterte Konfiguration verwenden</translation>
+        <translation>&amp;Erweiterte Konfiguration verwenden</translation>
     </message>
     <message>
         <location line="+9"/>

--- a/avidemux/qt4/i18n/avidemux_ru.ts
+++ b/avidemux/qt4/i18n/avidemux_ru.ts
@@ -2984,7 +2984,7 @@ Drop timing informations ?</source>
         <location line="+41"/>
         <location line="+41"/>
         <source>Configure</source>
-        <translation type="unfinished">Настройка</translation>
+        <translation type="unfinished">&amp;Настройка</translation>
     </message>
     <message>
         <source>Audio Filters</source>
@@ -2996,7 +2996,7 @@ Drop timing informations ?</source>
         <location line="+41"/>
         <location line="+41"/>
         <source>Filters</source>
-        <translation type="unfinished">Фильтры</translation>
+        <translation type="unfinished">&amp;Фильтры</translation>
     </message>
     <message>
         <location line="-164"/>
@@ -3006,7 +3006,7 @@ Drop timing informations ?</source>
     <message>
         <location line="+11"/>
         <source>Track 1</source>
-        <translation type="unfinished"></translation>
+        <translation>Дорожка 1</translation>
     </message>
     <message>
         <location line="+7"/>
@@ -3014,22 +3014,22 @@ Drop timing informations ?</source>
         <location line="+41"/>
         <location line="+41"/>
         <source>Enabled</source>
-        <translation type="unfinished">Включено</translation>
+        <translation type="unfinished">&amp;Включена</translation>
     </message>
     <message>
         <location line="-89"/>
         <source>Track 2</source>
-        <translation type="unfinished">Дорожка 2</translation>
+        <translation>Дорожка 2</translation>
     </message>
     <message>
         <location line="+41"/>
         <source>Track 3</source>
-        <translation type="unfinished">Дорожка 3</translation>
+        <translation>Дорожка 3</translation>
     </message>
     <message>
         <location line="+41"/>
         <source>Track 4</source>
-        <translation type="unfinished">Дорожка 4</translation>
+        <translation>Дорожка 4</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
After the recent update of the Russian translation a month ago, some obvious omissions from that update still remain uncorrected, so I hope that this is not too inappropriate to address the most visible one

![audio-track-ui-i18n-ru-missing-translation](https://cloud.githubusercontent.com/assets/23018873/21407888/12e4ebfe-c7d2-11e6-99cb-e618c507d9fc.png)

myself. The translation for "Track 1" was missing, causing misalignment, and the literal translation of "Enabled" as "Включено" (neuter) didn't match the gender of the translation for "Track" as "Дорожка" (feminine).

Using this opportunity, I would like to add keyboard accelerators in the German and in the Russian translation of the audio track selection dialog and to fix a single, broken keyboard accelerator in the German translation of the x265 configuration dialog.
