### PR TITLE
[flyDialog] Fix navigation slider (WIP), add missing tooltips

### DIFF
--- a/avidemux/qt4/ADM_UIs/include/DIA_flyDialogQt4.h
+++ b/avidemux/qt4/ADM_UIs/include/DIA_flyDialogQt4.h
@@ -145,7 +145,11 @@ public:
   virtual void     postInit(uint8_t reInit);
 public:  
   virtual uint8_t  sliderChanged(void);
+  virtual void     updateSlider(void);
   virtual bool     goToTime(uint64_t tme);
+
+private:
+  virtual bool     nextImageInternal(void);
   
 public slots:
         virtual bool nextImage(void);


### PR DESCRIPTION
This patch should fix wrong scaling by setting maximum value for the slider straight away in the constructor and make the slider approximately reflect the current position, albeit not during playback. It also adds missing tooltips to the navigation buttons.

There is a not yet understood disagreement between the slider value from `sliderGet` immediately after drag and after `nextImage`, the slider jumps slightly backwards.

The total duration accessed as `_in->getInfo()->totalDuration` is not updated if the changeFps filter is added. This might be an issue with underlying code and not the preview dialog's fault.