### PR TITLE
[plugins/changeFps] Fix navigation with the slider in the filter preview window

### DIFF
--- a/avidemux_plugins/ADM_videoFilters6/changeFps/changeFps.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/changeFps/changeFps.cpp
@@ -59,7 +59,6 @@ protected:
 public:
                             changeFps(ADM_coreVideoFilter *previous,CONFcouple *conf);
                             ~changeFps();
-        bool                goToTime(uint64_t usSeek);
         virtual const char   *getConfiguration(void);                   /// Return  current configuration as a human readable string
         virtual bool         getNextFrame(uint32_t *fn,ADMImage *image);    /// Return the next image
         virtual bool         getCoupledConf(CONFcouple **couples) ;   /// Return the current filter configuration
@@ -112,21 +111,6 @@ changeFps::changeFps(  ADM_coreVideoFilter *previous,CONFcouple *setup) : ADM_co
 */
 changeFps::~changeFps()
 {
-}
-
-/**
-    \fn goToTime
-    \brief called when seeking. Need to cleanup our stuff.
-*/
-bool         changeFps::goToTime(uint64_t usSeek)
-{
-    double timing=(double)usSeek;
-    timing/=configuration.oldFpsNum;
-    timing/=configuration.newFpsDen;
-    timing*=configuration.newFpsNum;
-    timing*=configuration.oldFpsDen;
-    if(false==ADM_coreVideoFilter::goToTime((uint64_t)timing)) return false;
-    return true;
 }
 
 /**


### PR DESCRIPTION
The reimplemented `goToTime` function was pulling the rug from under `ADM_flyDialog::sliderChanged` resulting in a [confusing behaviour](http://avidemux.org/smif/index.php/topic,17393.msg78917.html#msg78917) of the navigation slider in the filter preview window. What was the primary reason to rescale time?

[[changeFps] Working filter](https://github.com/mean00/avidemux2/commit/037bd7ccdcd2e36a13c5aba7f09ebf09f1c8f0a8)

It seems to work fine without that.