### PR TITLE
[UI] Preserve audio codec upon loading a video, now for real

### DIFF
--- a/avidemux/common/gui_main.cpp
+++ b/avidemux/common/gui_main.cpp
@@ -708,11 +708,18 @@ int A_openVideo (const char *name)
         res = video_body->addFile(longname);
 
     //  DIA_StopBusy ();
+    int ac=0; // audio codec = copy
     bool loadDefault;
     if(!prefs->get(RESET_ENCODER_ON_VIDEO_LOAD, &loadDefault)) loadDefault=false;
     // if true, discard changes in output config on video load
     if(loadDefault)
+    {
         A_loadDefaultSettings();
+        UI_setAudioCodec(ac); // revert to copy, we don't save default audio codec config yet
+    }else
+    {
+        ac=UI_getCurrentACodec();
+    }
     // forget last project file
     video_body->setProjectName("");
 
@@ -763,6 +770,8 @@ int A_openVideo (const char *name)
         prefs->set_lastfile(longname);
         UI_updateRecentMenu();
         updateLoaded();
+        if(video_body->getNumberOfActiveAudioTracks())
+            audioCodecSetByIndex(0,ac); // try to preserve audio codec
         if (currentaudiostream)
         {
             uint32_t nbAudio;


### PR DESCRIPTION
My earlier naive attempt to preserve audio codec at least for the first track across videos has only led to a disagreement between the codec widget in the main window and the audio tracks menu as noticed by users: [ 	
Encodage audio non sollicité mais automatique](http://avidemux.org/smif/index.php/topic,17401.0.html), [Audio options not remembered in 2.6.17-18](http://avidemux.org/smif/index.php/topic,17412.0.html). This quick and dirty patch fixes the disagreement, really restoring the previously selected audio codec for the first audio track.

The audio codec reverts to "copy" upon loading a new video if "load default settings" is checked.