### PR TITLE
[resampleFps] Apply the same logic as in changeFps to fix goToTime

### DIFF
--- a/avidemux_plugins/ADM_videoFilters6/resampleFps/ADM_vidResampleFPS.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/resampleFps/ADM_vidResampleFPS.cpp
@@ -155,7 +155,7 @@ bool resampleFps::refill(void)
 */
 bool         resampleFps::goToTime(uint64_t usSeek)
 {
-    if(false==ADM_coreVideoFilterCached::goToTime(usSeek)) return false;
+    if(false==previousFilter->goToTime(usSeek)) return false;
     prefillDone=false;
     return true;
 }


### PR DESCRIPTION
The `goToTime` function in the "resampleFps" plugin needs the already known [treatment](https://github.com/mean00/avidemux2/commit/2b6dd157d4fef93ad65e4948401401cdbdfcead0) (all credit for the fix goes to Mean, of course).