### PR TITLE
[flyDialog] Fix time display

### DIFF
--- a/avidemux/qt4/ADM_UIs/src/DIA_flyDialog.cpp
+++ b/avidemux/qt4/ADM_UIs/src/DIA_flyDialog.cpp
@@ -288,6 +288,8 @@ bool ADM_flyDialog::nextImageInternal(void)
     }
     lastPts=_yuvBuffer->Pts;
     setCurrentPts(lastPts);
+    if(_control)
+        _control->labelTime->setText(ADM_us2plain(lastPts));
     // Process...   
     process();
     return display(_rgbByteBufferDisplay.at(0));
@@ -305,8 +307,6 @@ bool ADM_flyDialog::nextImage(void)
     if(r)
         updateSlider();
     slide->blockSignals(oldState);
-
-    _control->labelTime->setText(ADM_us2plain(_yuvBuffer->Pts));
     return r;
 }
 


### PR DESCRIPTION
Maybe I'm missing something, but the time display (`labelTime`) added in [[flyDialog] more accurate timestamps + display pts](https://github.com/mean00/avidemux2/commit/c43557270c29704b68721b7747327ade5bf8770e) doesn't get updated in the most cases when navigating in a filter preview because `nextImage()` gets called only when clicking the "Next" button. I guess setting the text of the label belongs into `nextImageInternal()`.

Currently, adding time display to flyDialog results in duplicated time display in the seekable preview, where the new time display looks a bit out of place.