### PR TITLE
[seekablePreview] Show the total duration instead of the current PTS

### DIFF
--- a/avidemux/qt4/ADM_userInterfaces/ADM_filters/Q_seekablePreview.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_filters/Q_seekablePreview.cpp
@@ -64,7 +64,7 @@ void Ui_seekablePreviewWindow::resetVideoStream(ADM_coreVideoFilter *videoStream
 	canvas = new ADM_QCanvas(ui.frame, canvasWidth, canvasHeight);
 	canvas->show();
 	seekablePreview = new flySeekablePreview(this,canvasWidth, canvasHeight, videoStream, canvas, ui.horizontalSlider);	
-        seekablePreview->setCookieFunc(setCurrentPtsCallback,this);
+        setDuration(videoStream->getInfo()->totalDuration);
 	seekablePreview->sliderChanged();
 }
 /**
@@ -76,25 +76,12 @@ uint32_t Ui_seekablePreviewWindow::frameIndex()
 	return seekablePreview->sliderGet();
 }
 /**
-    \fn setCurrentPtsCallback
-    \brief callback so that the flyDialog can update its father widget
+    \fn setDuration
+    \brief Set total duration
 */
-bool Ui_seekablePreviewWindow::setCurrentPtsCallback(void *cookie,uint64_t pts)
+bool      Ui_seekablePreviewWindow::setDuration(uint64_t duration)
 {
-    if(cookie)
-    {
-        return ((Ui_seekablePreviewWindow *)cookie)->setTime(pts);
-    }
-    printf("No cookie, New PTS :%" PRId64" us\n",pts);
-    return true;
-}
-/**
-    \fn setTime
-    \brief Set timecode
-*/
-bool      Ui_seekablePreviewWindow::setTime(uint64_t timestamp)
-{
-    const char *s=ADM_us2plain(timestamp);
+    const char *s=ADM_us2plain(duration);
     ui.label->setText(s);
     return true;
 }

--- a/avidemux/qt4/ADM_userInterfaces/ADM_filters/Q_seekablePreview.h
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_filters/Q_seekablePreview.h
@@ -26,8 +26,6 @@
 class Ui_seekablePreviewWindow : public QDialog
 {
 	Q_OBJECT
-protected:
-    static bool setCurrentPtsCallback(void *cookie,uint64_t pts);
 public:
 	ADM_QCanvas         *canvas;
 	flySeekablePreview *seekablePreview;
@@ -38,7 +36,7 @@ public:
                 ~Ui_seekablePreviewWindow();
 	void    resetVideoStream(ADM_coreVideoFilter *videoStream);
 	uint32_t frameIndex();
-        bool     setTime(uint64_t timestamp);
+        bool     setDuration(uint64_t duration);
 public slots:
 	void sliderChanged(int value);
         


### PR DESCRIPTION
Obviously, we could use the label in the seekable preview currently duplicating the new functionality of the flyDialog to display the total duration of the filtered video instead.