### PR TITLE
[flyDialog] Update slider position during playback

### DIFF
--- a/avidemux/qt4/ADM_UIs/src/DIA_flyDialog.cpp
+++ b/avidemux/qt4/ADM_UIs/src/DIA_flyDialog.cpp
@@ -709,7 +709,6 @@ void ADM_flyDialog::play(bool state)
     {
         timer.stop();
         _control->enableButtons();
-        updateSlider();
         slide->setEnabled(true);
     }
     
@@ -738,7 +737,7 @@ void ADM_flyDialog::autoZoom(bool state)
 void ADM_flyDialog::timeout()
 {
     
-    bool r=nextImageInternal();
+    bool r=nextImage();
     _control->labelTime->setText(ADM_us2plain(_yuvBuffer->Pts));
     if(r)
     {


### PR DESCRIPTION
Replacing `nextImageInternal()` in `ADM_flyDialog::timeout` by `nextImage()` which updates the slider position is everything it needs to make the slider move during playback. The call to `updateSlider()` in `ADM_flyDialog::play` was my mistake and should be removed. 