### PR TITLE
[i18n] Don't translate strings passed to printString, the latter is ASCII-only

### DIFF
--- a/avidemux_plugins/ADM_videoFilters6/asharp/DIA_flyAsharp.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/asharp/DIA_flyAsharp.cpp
@@ -104,8 +104,8 @@ uint32_t ww,hh;
         dst[dstride]=0xff;
         dst+=dstride*2;
     }
-    out->printString(1,1,QT_TRANSLATE_NOOP("asharp", "Original"));
-    out->printString(ww/24+1,1,QT_TRANSLATE_NOOP("asharp", "Processed"));
+    out->printString(1,1,"Original"); // printString can't handle non-ascii input, do not translate this!
+    out->printString(ww/24+1,1,"Processed"); // as above, don't try to translate
     return 1;
 }
 //EOF

--- a/avidemux_plugins/ADM_videoFilters6/hue/qt4/DIA_flyHue.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/hue/qt4/DIA_flyHue.cpp
@@ -58,8 +58,8 @@ float hue,sat;
                  hue, sat);
     // Copy half source to display
     in->copyLeftSideTo(out);
-    out->printString(1,1,QT_TRANSLATE_NOOP("hue","Original"));
-    out->printString(in->GetWidth(PLANAR_Y)/24+1,1,QT_TRANSLATE_NOOP("hue","Processed"));
+    out->printString(1,1,"Original"); // printString can't handle non-ascii input, do not translate this!
+    out->printString(in->GetWidth(PLANAR_Y)/24+1,1,"Processed"); // as above, don't try to translate
 
     return 1;
 }

--- a/avidemux_plugins/ADM_videoFilters6/mSharpen/qt4/DIA_flymsharpen.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/mSharpen/qt4/DIA_flymsharpen.cpp
@@ -92,8 +92,8 @@ uint8_t    flyMSharpen::processYuv(ADMImage* in, ADMImage *out)
                 Msharpen::apply_filter(&refIn, blur, &refOut,  i,param,invstrength);
     }
     out->copyInfo(in);
-    out->printString(1,1,QT_TRANSLATE_NOOP("msharpen","Original"));
-    out->printString(in->GetWidth(PLANAR_Y)/24+1,1,QT_TRANSLATE_NOOP("msharpen","Processed"));
+    out->printString(1,1,"Original"); // printString can't handle non-ascii input, do not translate this!
+    out->printString(in->GetWidth(PLANAR_Y)/24+1,1,"Processed"); // as above, don't try to translate
 
     return 1;
 }


### PR DESCRIPTION
Just for convenience, partially reverts [[i18n] Make more strings translatable (Daniel Amm)](https://github.com/mean00/avidemux2/commit/3972605aa5777d95afc5fce035fc47bfb030b6a2) and adds comments based on [https://github.com/mean00/avidemux2/pull/86#issuecomment-277539015](https://github.com/mean00/avidemux2/pull/86#issuecomment-277539015), in case a rewrite of `printString` is not on the immediate agenda.