### PR TITLE
[core, qt] Use the base name of the currently loaded video as the default base name when saving

### DIFF
--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/file_qt4.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/file_qt4.cpp
@@ -49,14 +49,15 @@ static	void GUI_FileSelSelectWriteInternal(const char *label, const char *ext, c
     //printf("Do filer=%d\n",(int)doFilter);
     std::string lastFolder;
     admCoreUtils::getLastWriteFolder(lastFolder);
+    if(!lastFolder.size())
+        admCoreUtils::getLastReadFolder(lastFolder);
     if (lastFolder.size())
     {
         QString outputPath = QFileInfo(QString::fromUtf8(lastFolder.c_str())).path();
 
-        char *tmpinputname = NULL;
         QString inputBaseName = QString("");
         std::string lastRead;
-        admCoreUtils::getLastReadFolder(lastRead);
+        admCoreUtils::getLastReadFile(lastRead);
         if (lastRead.size())
         {
             inputBaseName = QFileInfo(QString::fromUtf8(lastRead.c_str())).completeBaseName();

--- a/avidemux_core/ADM_coreUtils/include/ADM_last.h
+++ b/avidemux_core/ADM_coreUtils/include/ADM_last.h
@@ -20,6 +20,8 @@ namespace admCoreUtils
 ADM_COREUTILS6_EXPORT void  setLastReadFolder(const std::string &folder);
 ADM_COREUTILS6_EXPORT void  getLastReadFolder( std::string &folder);
 
+ADM_COREUTILS6_EXPORT void  getLastReadFile( std::string &file);
+
 ADM_COREUTILS6_EXPORT void  setLastWriteFolder(const std::string &folder);
 ADM_COREUTILS6_EXPORT void  getLastWriteFolder( std::string &folder);
 

--- a/avidemux_core/ADM_coreUtils/src/ADM_last.cpp
+++ b/avidemux_core/ADM_coreUtils/src/ADM_last.cpp
@@ -72,4 +72,13 @@ void admCoreUtils::getLastWriteFolder( std::string &folder)
     
 }
 
+/**
+ * \fn getLastReadFile
+ * \brief get the file name and path of the currently loaded video
+ */
+ void admCoreUtils::getLastReadFile( std::string &file)
+ {
+     internalGetFolder(LASTFILES_FILE1,file);
+ }
+
 // EOF


### PR DESCRIPTION
The currently existing implementation uses the name of the last file opened via file picker to build the suggested base name of the output video. This is not desirable because a video may be loaded via the "Recent" menu instead.

The patch removes also a forgotten unused leftover of [[qt4] Provide a default filename when saving](https://github.com/mean00/avidemux2/commit/aaf1d9a16e0a1e209f1eb5543c4bdfcb1e9f72c6) and corrects the behaviour if no video has been saved yet and thus `LASTFILES_LASTDIR_WRITE` is empty: in this case `LASTFILES_LASTDIR_READ` is used instead of suggesting an empty string as file name for the output.

Reference: [Naming of saved files](http://avidemux.org/smif/index.php/topic,17304.0.html)