### PR TITLE
[UI] Resize the main window on unmaximizing

### DIFF
--- a/avidemux/common/ADM_commonUI/GUI_ui.h
+++ b/avidemux/common/ADM_commonUI/GUI_ui.h
@@ -18,9 +18,6 @@ void UI_setVProcessToggleStatus( uint8_t status );
 void    UI_iconify( void );
 void    UI_deiconify( void );
 
-uint32_t UI_requiredWidth(void);
-uint32_t UI_requiredHeight(void);
-
 int     UI_readCurFrame( void );
 int     UI_readCurTime(uint16_t &hh, uint16_t &mm, uint16_t &ss, uint16_t &ms);
 void    UI_JumpDone(void);

--- a/avidemux/common/ADM_render/GUI_render.h
+++ b/avidemux/common/ADM_render/GUI_render.h
@@ -60,6 +60,9 @@ void *UI_getDrawWidget(void);
 void UI_rgbDraw(void *widg,uint32_t w, uint32_t h,uint8_t *ptr);
 void UI_updateDrawWindowSize(void *win,uint32_t w,uint32_t h);
 void UI_getWindowInfo(void *draw, GUI_WindowInfo *xinfo);
+void UI_resize(uint32_t width, uint32_t height);
+bool UI_getNeedsResizingFlag(void);
+static bool needsResizing=false;
 
 /* The list of render engine we support. Warning the list is UI dependant, i.e. for example on macOsX, the GTK version can do Xv, but the QT4 one cannot */
 typedef enum 

--- a/avidemux/common/gui_main.cpp
+++ b/avidemux/common/gui_main.cpp
@@ -1458,6 +1458,7 @@ uint8_t GUI_close(void)
         admPreview::stop();
         setPreviewMode(ADM_PREVIEW_NONE);
       }
+      needsResizing=false;
       delete avifileinfo;
       //delete wavinfo;
       admPreview::destroy();

--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
@@ -795,6 +795,26 @@ void MainWindow::dropEvent(QDropEvent *event)
     }
 }
 
+// If a video was loaded or zoom changed while the main window was maximized,
+// unmaximizing the window restores it to dimensions not necessarily matching
+// the actual dimensions of the video frame. Catch the window state change event
+// and resize the window when appropriate.
+void MainWindow::changeEvent(QEvent *event)
+{
+    if (event->type() == QEvent::WindowStateChange)
+    {
+        QWindowStateChangeEvent* ev = static_cast<QWindowStateChangeEvent*>(event);
+        if (true==UI_getNeedsResizingFlag() && ev->oldState() == Qt::WindowMaximized && false==QuiMainWindows->isMinimized())
+        {
+            uint32_t w=ui.frame_video->width();
+            uint32_t h=ui.frame_video->height();
+            UI_resize(w,h);
+            needsResizing=false;
+        }
+    }
+    QWidget::changeEvent(event);
+}
+
 void MainWindow::openFiles(QList<QUrl> urlList)
 {
     QFileInfo info;
@@ -1529,24 +1549,17 @@ void UI_deiconify( void )
     }
 }
 /**
- *   \fn UI_requiredWidth
- *   \brief calculate the horizontal space occupied by the coded widget incl. some margin
+ *    \fn UI_resize
+ *    \brief resize the main window for the given dimensions of the video widget
  */
-uint32_t UI_requiredWidth(void)
+void UI_resize(uint32_t w,uint32_t h)
 {
     uint32_t reqw=18; // 2 x 9px margin
     if(WIDGET(codecWidget)->isVisible())
         reqw += WIDGET(codecWidget)->frameSize().width() + 6; // with codec widget visible a small extra margin is necessary
     if(WIDGET(toolBar)->orientation()==Qt::Vertical && WIDGET(toolBar)->isVisible() && false==WIDGET(toolBar)->isFloating())
         reqw += WIDGET(toolBar)->frameSize().width();
-    return reqw;
-}
-/**
- *   \fn UI_requiredHeight
- *   \brief calculate the vertical space occupied by widgets above and below the video window
- */
-uint32_t UI_requiredHeight(void)
-{
+
     uint32_t reqh=18; // 2 x 9px margin
     if(WIDGET(menubar)->isVisible())
         reqh += WIDGET(menubar)->height();
@@ -1554,7 +1567,11 @@ uint32_t UI_requiredHeight(void)
         reqh += WIDGET(toolBar)->frameSize().height();
     if(WIDGET(navigationWidget)->isVisible() || WIDGET(selectionWidget)->isVisible() || WIDGET(volumeWidget)->isVisible() || WIDGET(audioMetreWidget)->isVisible())
         reqh += WIDGET(navigationWidget)->frameSize().height();
-    return reqh;
+
+    reqw += w;
+    reqh += h;
+    QuiMainWindows->resize(reqw,reqh);
+    ADM_info("Resizing the main window to %dx%d px\n",reqw,reqh);
 }
 /**
     \fn UI_setAudioTrackCount

--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.h
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.h
@@ -191,5 +191,6 @@ protected:
 	void dragEnterEvent(QDragEnterEvent *event);
 	void dropEvent(QDropEvent *event);
 	void openFiles(QList<QUrl>);
+        void changeEvent(QEvent* event);
 };
 #endif	// Q_gui2_h

--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/T_preview.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/T_preview.cpp
@@ -169,12 +169,14 @@ void  UI_updateDrawWindowSize(void *win,uint32_t w,uint32_t h)
 
     // Resizing a maximized window results in not refreshed areas where widgets 
     // in the maximized state were drawn with Qt5 on Linux, try to avoid this.
-    // TODO: Resize the main window on restore event.
+    // Instead, resize the window later on restore event if necessary.
     if(!QuiMainWindows->isMaximized())
     {
-        uint32_t extra_w=UI_requiredWidth();
-        uint32_t extra_h=UI_requiredHeight();
-        QuiMainWindows->resize(w+extra_w,h+extra_h);
+        UI_resize(w,h);
+        needsResizing=false;
+    }else
+    {
+        needsResizing=true;
     }
     videoWindow->setADMSize(w,h);
 #if 0
@@ -195,6 +197,12 @@ void  UI_updateDrawWindowSize(void *win,uint32_t w,uint32_t h)
 
 	printf("[RDR] Resizing to %u x %u\n", displayW, displayH);
 }
+
+bool UI_getNeedsResizingFlag(void)
+{
+    return needsResizing;
+}
+
 /**
       \brief Retrieve info from window, needed for accel layer
 */


### PR DESCRIPTION
If a new video was loaded or the zoom was changed while the Avidemux window was maximized, unmaximizing the window would restore its size prior to entering the maximized state regardless the actual dimensions of the video. This patch implements automatic resizing in this case.