### PR TITLE
[vdpau] Don't crash with WMV3 videos

### DIFF
--- a/avidemux/common/ADM_videoCodec/src/ADM_ffmpeg_vdpau.cpp
+++ b/avidemux/common/ADM_videoCodec/src/ADM_ffmpeg_vdpau.cpp
@@ -304,6 +304,9 @@ decoderFFVDPAU::decoderFFVDPAU(struct AVCodecContext *avctx,decoderFF *parent) :
             case AV_CODEC_ID_MPEG2VIDEO:
                   name="mpegvideo";
                   break;
+            case AV_CODEC_ID_WMV3:
+                  name="wm3_vdpau";
+                  break;
             default:
                 ADM_assert(0);
                 break;


### PR DESCRIPTION
`vdpauGetFormat` accepts WMV3 as supported by hardware (vdpauinfo doesn't list WMV3 as supported, but mpv claims decoding .wmv videos via VDPAU and plays them perfectly), but `decoderFFVDPAU` knows nothing about that resulting in a crash.

It is worth noting that WMV is almost completely broken and unusable in Avidemux, no matter which decoder.