### PR TITLE
[mixDump] Print a newline at the end, remove workarounds all over the tree

### DIFF
--- a/avidemux/common/ADM_editor/src/ADM_edit.cpp
+++ b/avidemux/common/ADM_editor/src/ADM_edit.cpp
@@ -263,7 +263,6 @@ bool ADM_Composer::addFile (const char *name)
     {
         printf("[Editor]The video codec has some extradata (%d bytes)\n",l);
         mixDump(d,l);
-        printf("\n");
     }
 
   // 1st if it is our first video we update postproc

--- a/avidemux_core/ADM_coreUtils/src/ADM_infoExtractorH264.cpp
+++ b/avidemux_core/ADM_coreUtils/src/ADM_infoExtractorH264.cpp
@@ -787,7 +787,7 @@ uint8_t extractSPSInfo_lavcodec (uint8_t * data, uint32_t len, ADM_SPSInfo *spsi
     ADM_info("Incoming SPS info\n");
     mixDump(data,len);
 
-    ADM_info("\nconverted SPS info\n");
+    ADM_info("converted SPS info\n");
 
     uint32_t converted;
     uint8_t buffer[256];
@@ -797,7 +797,6 @@ uint8_t extractSPSInfo_lavcodec (uint8_t * data, uint32_t len, ADM_SPSInfo *spsi
         return false;
     }
     mixDump(buffer,converted);
-    ADM_info("\n");
     return    extractSPSInfo_mp4Header(buffer,converted,spsinfo) ;
 
 }

--- a/avidemux_core/ADM_coreUtils/src/avidemutils.cpp
+++ b/avidemux_core/ADM_coreUtils/src/avidemutils.cpp
@@ -81,6 +81,7 @@ void mixDump(uint8_t * ptr, uint32_t len)
 	{
 		 printf("\n %04" PRIx32" : %s %s", (len >> 4) << 4, str, str2);
 	}
+    printf("\n");
 }
 /*
 	A bunch of Endianness swapper to ease handling

--- a/avidemux_plugins/ADM_audioDecoders/ADM_ad_lav/ADM_ad_lav.cpp
+++ b/avidemux_plugins/ADM_audioDecoders/ADM_ad_lav/ADM_ad_lav.cpp
@@ -205,7 +205,6 @@ DECLARE_AUDIO_DECODER(ADM_AudiocoderLavcodec,						// Class
 
     ADM_info("[ADM_AD_LAV] Using %d bytes of extra header data, %d channels\n", _context->extradata_size,_context->channels);
     mixDump((uint8_t *)_context->extradata,_context->extradata_size);
-    ADM_info("\n");
     
     if (avcodec_open2(_context, codec, NULL) < 0)
     {

--- a/avidemux_plugins/ADM_audioDecoders/ADM_ad_vorbis/ADM_ad_vorbis.cpp
+++ b/avidemux_plugins/ADM_audioDecoders/ADM_ad_vorbis/ADM_ad_vorbis.cpp
@@ -81,7 +81,6 @@ DECLARE_AUDIO_DECODER(ADM_vorbis,                        // Class
  {
      ADM_warning(" sending %s packet of size %d\n",name,pack->bytes);
      mixDump(pack->packet,pack->bytes);
-     ADM_warning("\n");
  }
  /**
   * 

--- a/avidemux_plugins/ADM_demuxers/Matroska/ADM_mkvEntries.cpp
+++ b/avidemux_plugins/ADM_demuxers/Matroska/ADM_mkvEntries.cpp
@@ -220,7 +220,6 @@ uint8_t mkvHeader::analyzeOneTrack(void *head,uint32_t headlen)
                 memcpy(_tracks[0].extraData,entry.extraData +sizeof(ADM_BITMAPINFOHEADER),l);
                 ADM_info("VFW Header+%d bytes of extradata\n",l);   
                 mixDump(_tracks[0].extraData,l);
-                printf("\n");
           }
           delete [] entry.extraData;
           entry.extraData=NULL;
@@ -258,7 +257,7 @@ uint8_t mkvHeader::analyzeOneTrack(void *head,uint32_t headlen)
             ADM_info("Found ACM compatibility header (%d / %d)\n",l,wavSize);
             if(l>=wavSize) // we need at least a wavheader
             {
-                mixDump(entry.extraData,l); printf("\n");
+                mixDump(entry.extraData,l);
                 memcpy(&(t->wavHeader),entry.extraData,wavSize);
                 ADM_info("Encoding : %d\n",t->wavHeader.encoding);
                 int x=l-wavSize;

--- a/avidemux_plugins/ADM_demuxers/Mp4/ADM_mp4Analyzer.cpp
+++ b/avidemux_plugins/ADM_demuxers/Mp4/ADM_mp4Analyzer.cpp
@@ -880,7 +880,7 @@ nextAtom:
                                             mixDump(VDEO.extraData+offset,len);
 
                                             offset=8+len;
-                                            printf("\navcC numOfPictureParSets  :%x\n", MKD8(offset++));
+                                            printf("avcC numOfPictureParSets  :%x\n", MKD8(offset++));
                                             len=MKD16(offset);
                                             offset++;
                                             printf("avcC Pic len              :%x\n",len);

--- a/avidemux_plugins/ADM_demuxers/MpegTS/ADM_tsAudio.cpp
+++ b/avidemux_plugins/ADM_demuxers/MpegTS/ADM_tsAudio.cpp
@@ -53,7 +53,6 @@ FP_TYPE fp=FP_DONT_APPEND;
             memcpy(extraData,myExtra,extraDataLen);
             ADM_info("Creating ts audio access with %d bytes of extradata.",myLen);
             mixDump(extraData,extraDataLen);
-            ADM_info("\n");
         }
 }
 

--- a/avidemux_plugins/ADM_demuxers/OpenDml/ADM_openDML.cpp
+++ b/avidemux_plugins/ADM_demuxers/OpenDml/ADM_openDML.cpp
@@ -726,7 +726,6 @@ void OpenDMLHeader::Dump( void )
 	if(_videoExtraLen)
 	{
 		mixDump( _videoExtraData, _videoExtraLen);
-        printf("\n");
 	}
 
 	printf("[Avi]  fccType     :");
@@ -799,7 +798,6 @@ void OpenDMLHeader::Dump( void )
 	{
 		mixDump( _audioTracks[i].extraData, _audioTracks[i].extraDataLen);
 	}
-	printf("\n");
 
       }
 }

--- a/avidemux_plugins/ADM_muxers/muxerMp4v2/muxerMp4v2Video.cpp
+++ b/avidemux_plugins/ADM_muxers/muxerMp4v2/muxerMp4v2Video.cpp
@@ -127,7 +127,7 @@ bool muxerMp4v2::initMpeg4(void)
             esdsLen-=4;
         }
 
-        ADM_info("Esds:\n"); mixDump(esdsData,esdsLen);ADM_info("\n");            
+        ADM_info("Esds:\n"); mixDump(esdsData,esdsLen);
         if(false==MP4SetTrackESConfiguration(handle,videoTrackId,esdsData,esdsLen))
         {
             ADM_error("SetTracEsConfiguration failed\n");
@@ -164,7 +164,6 @@ bool muxerMp4v2::initH264(void)
             }
             if(extraLen)
                 mixDump(extra,extraLen);
-            ADM_info("\n");
             if(false==ADM_getH264SpsPpsFromExtraData(extraLen,extra,&spsLen,&spsData,&ppsLen,&ppsData))
             {
                 ADM_error("Wrong extra data for h264\n");
@@ -193,7 +192,6 @@ bool muxerMp4v2::initH264(void)
             mixDump(spsData,spsLen);
             ADM_info("PPS (%d) :",ppsLen);
             mixDump(ppsData,ppsLen);
-            ADM_info("\n");
 
             MP4AddH264SequenceParameterSet(handle,videoTrackId, spsData,spsLen );
             MP4AddH264PictureParameterSet( handle,videoTrackId, ppsData,ppsLen);


### PR DESCRIPTION
Since `ADM_info` and `ADM_warning` print timestamps, the result of a lot of workarounds for missing newline at the end of `mixDump` output where `ADM_info("\n");` is used instead looks very wrong. This patch adds the final newline to `mixDump` itself and removes all active (not commented out and not hidden in leftovers like *.orig files in `avidemux_plugins/ADM_demuxers/Mp4` directory) workarounds across the tree.