### PR TITLE
[desktop integration] Add AppData file

### DIFF
--- a/avidemux2.appdata.xml
+++ b/avidemux2.appdata.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2017 Adrien Vergé -->
+<component type="desktop-application">
+    <id>avidemux2.desktop</id>
+    <metadata_license>CC0</metadata_license>
+    <name>Avidemux</name>
+    <summary>Multi-purpose video editing and processing software</summary>
+    <description>
+        <p>
+            Avidemux is a free open-source program designed for multi-purpose
+            video editing and processing, which can be used on almost all known
+            operating systems and computer platforms.
+        </p>
+    </description>
+    <categories>
+        <category>AudioVideo</category>
+        <category>AudioVideoEditing</category>
+        <category>Video</category>
+    </categories>
+    <url type="homepage">https://www.avidemux.org/</url>
+    <provides>
+        <binary>avidemux2_gtk</binary>
+    </provides>
+    <project_license>GPL-2.0+</project_license>
+    <update_contact>Avidemux team -- avidemux.org/smif/</update_contact>
+    <screenshots>
+        <screenshot type="default">http://fixounet.free.fr/avidemux/index_files/screenshot1.png</screenshot>
+        <screenshot type="default">http://fixounet.free.fr/avidemux/index_files/screenshot2.png</screenshot>
+    </screenshots>
+</component>


### PR DESCRIPTION
AppData is a standard to describe GUI applications. In particular, it allows these applications to be searched for and installed through software centers on Fedora, Ubuntu, etc.

This commit embeds a `.appdata.xml` file for Avidemux, so my grandmother can install it without having to open a terminal.

For further information on AppData see:
https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html#sect-Quickstart-DesktopApps

Related to: https://github.com/rpmfusion/avidemux/pull/6