### PR TITLE
[vdpau] Fix detection of support for MPEG-2

### DIFF
--- a/avidemux/common/ADM_videoCodec/src/ADM_ffmpeg_vdpau.cpp
+++ b/avidemux/common/ADM_videoCodec/src/ADM_ffmpeg_vdpau.cpp
@@ -230,7 +230,7 @@ static enum AVPixelFormat vdpauGetFormat(struct AVCodecContext *avctx,  const en
                 FMT_V_CHECK(H264,      VDP_DECODER_PROFILE_H264_HIGH)
                 FMT_V_CHECK(HEVC,      VDP_DECODER_PROFILE_HEVC_MAIN) 
                 FMT_V_CHECK(MPEG1VIDEO,VDP_DECODER_PROFILE_MPEG1)
-                FMT_V_CHECK(MPEG2VIDEO,VDP_DECODER_LEVEL_MPEG2_HL)
+                FMT_V_CHECK(MPEG2VIDEO,VDP_DECODER_PROFILE_MPEG2_MAIN)
                 FMT_V_CHECK(WMV3,      VDP_DECODER_PROFILE_VC1_MAIN)
                 FMT_V_CHECK(VC1,       VDP_DECODER_PROFILE_VC1_MAIN)
                 default: 


### PR DESCRIPTION
This is a trivial fix for mpeg2 decoding via VDPAU not working after [[vdpau] Probe hw capabilities (experimental)](https://github.com/mean00/avidemux2/commit/868f24f0e70e6b8a559c467407af145eb23eb1bc).