### PR TITLE
[UI] Resize on unmaximize, slightly less ugly

### DIFF
--- a/avidemux/cli/ADM_userInterfaces/ADM_gui2/gui_none.cpp
+++ b/avidemux/cli/ADM_userInterfaces/ADM_gui2/gui_none.cpp
@@ -171,4 +171,6 @@ bool UI_setDisplayName(char const*)
 {
         return true;
 }
+void UI_setNeedsResizingFlag(bool resize)
+{}
 // EOF

--- a/avidemux/common/ADM_render/GUI_render.h
+++ b/avidemux/common/ADM_render/GUI_render.h
@@ -62,7 +62,7 @@ void UI_updateDrawWindowSize(void *win,uint32_t w,uint32_t h);
 void UI_getWindowInfo(void *draw, GUI_WindowInfo *xinfo);
 void UI_resize(uint32_t width, uint32_t height);
 bool UI_getNeedsResizingFlag(void);
-static bool needsResizing=false;
+void UI_setNeedsResizingFlag(bool resize);
 
 /* The list of render engine we support. Warning the list is UI dependant, i.e. for example on macOsX, the GTK version can do Xv, but the QT4 one cannot */
 typedef enum 

--- a/avidemux/common/gui_main.cpp
+++ b/avidemux/common/gui_main.cpp
@@ -1458,7 +1458,7 @@ uint8_t GUI_close(void)
         admPreview::stop();
         setPreviewMode(ADM_PREVIEW_NONE);
       }
-      needsResizing=false;
+      UI_setNeedsResizingFlag(false);
       delete avifileinfo;
       //delete wavinfo;
       admPreview::destroy();

--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
@@ -107,6 +107,8 @@ extern void ADM_ExitCleanup(void);
 static bool uiRunning=false;
 static bool uiIsMaximized=false;
 
+bool needsResizing=false;
+
 #define WIDGET(x)  (((MainWindow *)QuiMainWindows)->ui.x)
 
 #define CONNECT(object,zzz) connect( (ui.object),SIGNAL(triggered()),this,SLOT(buttonPressed()));
@@ -809,7 +811,7 @@ void MainWindow::changeEvent(QEvent *event)
             uint32_t w=ui.frame_video->width();
             uint32_t h=ui.frame_video->height();
             UI_resize(w,h);
-            needsResizing=false;
+            UI_setNeedsResizingFlag(false);
         }
     }
     QWidget::changeEvent(event);
@@ -1573,6 +1575,23 @@ void UI_resize(uint32_t w,uint32_t h)
     QuiMainWindows->resize(reqw,reqh);
     ADM_info("Resizing the main window to %dx%d px\n",reqw,reqh);
 }
+
+/**
+    \fn UI_getNeedsResizingFlag
+*/
+bool UI_getNeedsResizingFlag(void)
+{
+    return needsResizing;
+}
+
+/**
+    \fn UI_setNeedsResizingFlag
+*/
+void UI_setNeedsResizingFlag(bool resize)
+{
+    needsResizing=resize;
+}
+
 /**
     \fn UI_setAudioTrackCount
 */

--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/T_preview.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/T_preview.cpp
@@ -173,10 +173,10 @@ void  UI_updateDrawWindowSize(void *win,uint32_t w,uint32_t h)
     if(!QuiMainWindows->isMaximized())
     {
         UI_resize(w,h);
-        needsResizing=false;
+        UI_setNeedsResizingFlag(false);
     }else
     {
-        needsResizing=true;
+        UI_setNeedsResizingFlag(true);
     }
     videoWindow->setADMSize(w,h);
 #if 0
@@ -196,11 +196,6 @@ void  UI_updateDrawWindowSize(void *win,uint32_t w,uint32_t h)
 	UI_purge();
 
 	printf("[RDR] Resizing to %u x %u\n", displayW, displayH);
-}
-
-bool UI_getNeedsResizingFlag(void)
-{
-    return needsResizing;
 }
 
 /**


### PR DESCRIPTION
This patch replaces a global variable introduced in [[UI] Resize the main window on unmaximizing](https://github.com/mean00/avidemux2/commit/c2c994ca706d1bf35552e4736e2e8d074eb89650) with a setter function.