### PR TITLE
[render] Avoid trying to use VDPAU render with zero size dimensions

### DIFF
--- a/avidemux/common/ADM_render/GUI_vdpauRender.cpp
+++ b/avidemux/common/ADM_render/GUI_vdpauRender.cpp
@@ -66,6 +66,11 @@ vdpauRender::~vdpauRender()
 */
 bool vdpauRender::init( GUI_WindowInfo * window, uint32_t w, uint32_t h,renderZoom zoom)
 {
+    if(!w || !h)
+    {
+        ADM_info("[VDPAU] Not trying to initialize with zero size dimensions\n");
+        return false;
+    }
     ADM_info("[Vdpau]Init\n");
     info=*window;
     if(admVdpau::isOperationnal()==false)


### PR DESCRIPTION
VDPAU won't initialize with width and height equal zero, spitting error messages in red into the terminal every time a video is closed. Don't try it in the first place.