### PR TITLE
[UI] Refresh the main window on closing a video

### DIFF
--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/T_preview.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/T_preview.cpp
@@ -179,6 +179,8 @@ void  UI_updateDrawWindowSize(void *win,uint32_t w,uint32_t h)
         UI_setNeedsResizingFlag(true);
     }
     videoWindow->setADMSize(w,h);
+    if(!w || !h)
+        QuiMainWindows->update(); // clean up the space previously occupied by the video window on closing
 #if 0
 	
 	UI_purge();


### PR DESCRIPTION
This clears leftovers of previously displayed videos on closing, especially bad with the "Qt" video output.