### PR TITLE
[cosmetics] Add newline after fourcc::print at some locations

### DIFF
--- a/avidemux/common/ADM_editor/src/ADM_edit.cpp
+++ b/avidemux/common/ADM_editor/src/ADM_edit.cpp
@@ -356,6 +356,7 @@ bool ADM_Composer::addFile (const char *name)
 
   printf ("[Editor] Decoder FCC: ");
   fourCC::print (info.fcc);
+  printf("\n");
   // ugly hack
   if (info.fps1000 > 2000 * 1000)
     {

--- a/avidemux/common/ADM_videoCodec/src/ADM_videoCodec.cpp
+++ b/avidemux/common/ADM_videoCodec/src/ADM_videoCodec.cpp
@@ -40,7 +40,7 @@ decoders *tryCreatingVideoDecoder(uint32_t w, uint32_t h, uint32_t fcc,uint32_t 
 decoders *ADM_getDecoder (uint32_t fcc, uint32_t w, uint32_t h, uint32_t extraLen, 
             uint8_t * extraData,uint32_t bpp)
 {
-    ADM_info("\nSearching decoder in plugins\n");
+    ADM_info("Searching decoder in plugins\n");
     decoders *fromPlugin=tryCreatingVideoDecoder(w,h,fcc,extraLen,extraData,bpp);
     if(fromPlugin) 
         return fromPlugin;

--- a/avidemux_core/ADM_coreVideoCodec/src/ADM_codecSearch.cpp
+++ b/avidemux_core/ADM_coreVideoCodec/src/ADM_codecSearch.cpp
@@ -136,8 +136,9 @@ decoders *ADM_coreCodecGetDecoder (uint32_t fcc, uint32_t w, uint32_t h, uint32_
     }
 
   // default : null decoder
-  printf ("\n using invalid codec for \n");
+  printf ("\n using invalid codec for ");
   fourCC::print (fcc);
+  printf ("\n");
 
   return (decoders *) (new decoderEmpty(w,h,fcc,extraLen,extraData,bpp));
 }

--- a/avidemux_plugins/ADM_demuxers/OpenDml/ADM_openDML.cpp
+++ b/avidemux_plugins/ADM_demuxers/OpenDml/ADM_openDML.cpp
@@ -682,8 +682,8 @@ uint32_t count=0;
                                 }
                                 else
                                 {
-                                        printf("Track %u/%u :\n",i,_nbTrack);
-                                        fourCC::print(tmp.fccType);
+                                        printf("Track %u/%u : ",i,_nbTrack);
+                                        fourCC::print(tmp.fccType);printf(", ");
                                         fourCC::print(tmp.fccHandler);
                                         printf("\n");
                                 }
@@ -722,7 +722,7 @@ void OpenDMLHeader::Dump( void )
 				
 	printf(  "[Avi] video stream attached:\n" );
 	printf(  "[Avi] ______________________\n" );	
-	printf(  "[Avi] Extra Data  : %u",_videoExtraLen);
+	printf(  "[Avi] Extra Data  : %u\n",_videoExtraLen);
 	if(_videoExtraLen)
 	{
 		mixDump( _videoExtraData, _videoExtraLen);


### PR DESCRIPTION
This is merely a cosmetic change improving legibility of debug output, which suffers from a few missing (or excessive) newlines mostly but not exclusively in connection with usage of `fourcc::print` function.

There are some spots in the (mostly debug) code which rely on `fourcc::print` **not** including a final newline thus preventing a more straightforward approach which would allow to scrap a lot of `printf("\n");` all over the tree.