### PR TITLE
[UI] Allow resetting markers from GUI

### DIFF
--- a/avidemux/common/ADM_commonUI/myOwnMenu.h
+++ b/avidemux/common/ADM_commonUI/myOwnMenu.h
@@ -60,6 +60,7 @@ static const MenuEntry _myMenuEdit[] = {
             {MENU_SEPARATOR,"-",NULL,ACT_DUMMY             ,NULL,       NULL},
             {MENU_ACTION,QT_TRANSLATE_NOOP("adm","Set Marker A"),       NULL,ACT_MarkA      ,NULL,"Ctrl+PgUp"},
             {MENU_ACTION,QT_TRANSLATE_NOOP("adm","Set Marker B"),       NULL,ACT_MarkB      ,NULL,"Ctrl+PgDown"},
+            {MENU_ACTION,QT_TRANSLATE_NOOP("adm","Reset Markers"),      NULL,ACT_ResetMarkers,NULL,"Ctrl+Home"},
             {MENU_SEPARATOR,"-",NULL,ACT_DUMMY             ,NULL,       NULL},
             {MENU_ACTION,QT_TRANSLATE_NOOP("adm","Pr&eferences"),       NULL,ACT_PREFERENCES,NULL,NULL},
             {MENU_SEPARATOR,"-",NULL,ACT_DUMMY             ,NULL,NULL},

--- a/avidemux/common/gui_action.names
+++ b/avidemux/common/gui_action.names
@@ -68,6 +68,7 @@ ACT(VIDEO_CODEC_CHANGED)
 // Editor
 ACT(MarkA)
 ACT(MarkB)
+ACT(ResetMarkers)
 ACT(Copy)
 ACT(Cut)
 ACT(Paste)

--- a/avidemux/common/gui_main.cpp
+++ b/avidemux/common/gui_main.cpp
@@ -471,6 +471,16 @@ void HandleAction (Action action)
         UI_setMarkers (markA, markB);
       break;
     }
+    case ACT_ResetMarkers:
+    {
+        if(!video_body->getMarkerAPts() && video_body->getMarkerBPts()==video_body->getVideoDuration())
+            break; // do nothing if the markers were not moved
+        video_body->addToUndoQueue();
+        A_ResetMarkers();
+        A_Resync();
+        GUI_setCurrentFrameAndTime();
+        break;
+    }
     case ACT_Copy:
     {
                 uint64_t markA,markB;


### PR DESCRIPTION
Once again upon [request](http://avidemux.org/smif/index.php/topic,17465.msg79418.html#msg79418). This patch exposes resetting markers in GUI with Ctrl+Home as keyboard shortcut.