### PR TITLE
[encoding] Use encoding dialog for the first pass (no re-use yet)

### DIFF
--- a/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_encoding.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_encoding.cpp
@@ -105,7 +105,9 @@ DIA_encodingQt4::DIA_encodingQt4(uint64_t duration) : DIA_encodingBase(duration)
                 
 	}else
         {
-            ui->comboBoxPriority->setEnabled(false);
+            ui->comboBoxPriority->setVisible(false);
+            ui->checkBoxShutdown->setVisible(false);
+            ui->labelPrio->setVisible(false);
         }
 #endif
 
@@ -176,9 +178,20 @@ DIA_encodingQt4::~DIA_encodingQt4( )
 
 void DIA_encodingQt4::setPhasis(const char *n)
 {
-          ADM_assert(ui);
-          WRITEM(labelPhasis,n);
-
+    ADM_assert(ui);
+    if(!strcmp(n,"Pass 1"))
+    {
+        ui->tabWidget->setTabEnabled(1, false); // disable the "Advanced" tab
+        ui->checkBoxShutdown->setVisible(false); // hide the shutdown checkbox
+        WRITEM(labelPhasis,QT_TRANSLATE_NOOP("qencoding","Pass 1"));
+    }else
+    {
+        ui->tabWidget->setTabEnabled(1, true);
+#ifdef _WIN32
+        ui->checkBoxShutdown->setVisible(true);
+#endif
+        WRITEM(labelPhasis,n);
+    }
 }
 /**
     \fn    setFrameCount

--- a/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_encoding.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_encoding.cpp
@@ -183,9 +183,11 @@ void DIA_encodingQt4::setPhasis(const char *n)
     {
         ui->tabWidget->setTabEnabled(1, false); // disable the "Advanced" tab
         ui->checkBoxShutdown->setVisible(false); // hide the shutdown checkbox
+        this->setWindowTitle(QT_TRANSLATE_NOOP("qencoding","First Pass"));
         WRITEM(labelPhasis,QT_TRANSLATE_NOOP("qencoding","Pass 1"));
     }else
     {
+        this->setWindowTitle(QT_TRANSLATE_NOOP("qencoding","Encoding..."));
         ui->tabWidget->setTabEnabled(1, true);
 #ifdef _WIN32
         ui->checkBoxShutdown->setVisible(true);

--- a/avidemux/qt4/ADM_userInterfaces/ADM_dialog/encoding.ui
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_dialog/encoding.ui
@@ -119,7 +119,7 @@ p, li { white-space: pre-wrap; }
           </spacer>
          </item>
          <item>
-          <widget class="QLabel" name="label">
+          <widget class="QLabel" name="labelPrio">
            <property name="text">
             <string>Priority:</string>
            </property>

--- a/avidemux_core/ADM_coreUI/include/DIA_encoding.h
+++ b/avidemux_core/ADM_coreUI/include/DIA_encoding.h
@@ -51,6 +51,7 @@ protected:
                 uint32_t  _originalPriority;
                 encodingSample samples[ADM_ENCODING_SAMPLE];
                 uint32_t  sampleIndex;
+                uint32_t  percent;
         
 public:
                              DIA_encodingBase(uint64_t duration);
@@ -65,14 +66,13 @@ protected:
                 virtual void setTotalSize(uint64_t size)=0;
                 virtual void setFrameCount(uint32_t nb)=0;
                 virtual void setElapsedTimeMs(uint32_t nb)=0;
-                virtual void setRemainingTimeMS(uint32_t nb)=0;
                 virtual void setAverageQz(uint32_t nb)=0;
                 virtual void setAverageBitrateKbits(uint32_t kb)=0;
             
 
 public:
                 virtual void setPercent(uint32_t percent)=0;
-public:
+                virtual void setRemainingTimeMS(uint32_t nb)=0;
                 virtual void setPhasis(const char *n)=0;
                 virtual void setVideoCodec(const char *n)=0;
                 virtual void setAudioCodec(const char *n)=0;

--- a/avidemux_core/ADM_coreUI/src/DIA_encoding.cpp
+++ b/avidemux_core/ADM_coreUI/src/DIA_encoding.cpp
@@ -61,6 +61,7 @@ void DIA_encodingBase::reset(void)
         _fps_average=0;
         _remainingTimeUs=0;
         sampleIndex=0;
+        percent=0;
         memset(samples,0,sizeof(samples));
         clock.reset();
         UI_purge();
@@ -138,10 +139,12 @@ void DIA_encodingBase::refresh(void)
                     _fps_average=_fps_average*0.5+0.5*thisAverage;
                     //printf("************** Fps:%d\n",(int)_fps_average);
                     setFps(_fps_average);
-                    float percent=(float)_currentDts/(float)_totalDurationUs;
-                    if(percent>1.0) percent=1.0;
-                    percent*=100;
-                    setPercent((uint32_t)percent);
+                    float p=(float)_currentDts/(float)_totalDurationUs;
+                    if(p>1.0) p=1.0;
+                    p*=100;
+                    if(percent<(uint32_t)p)
+                        percent=(uint32_t)p; // avoid progress bar going backwards
+                    setPercent(percent);
                     setFrameCount(_currentFrameCount);
                     setElapsedTimeMs(time);
                 }


### PR DESCRIPTION
This patch falls way short of the goal to use the single instance of the encoding dialog for both the first and the second pass. It just replaces the working dialog with the encoding one for the first pass with related additional tweaks like disabling the "Advanced" tab and making information about remaining time available. The benefit: it is now possible to minimize Avidemux to the notification area during the first pass too (see [reference](http://avidemux.org/smif/index.php/topic,12493.0.html)). Without re-use of the dialog instance, the application window will pop up after the first pass though.

The patch makes also the "Pass 1" translatable and hides the disfunctional shutdown checkbox and priority  combo – on Linux and Mac completely, on Windows only for the first pass. The name of the priority label is changed to clarify its purpose when used in code elsewhere.

Automatic shutdown after  encoding can't work now, of course, as the value of `shutdownRequired` is not evaluated in the destructor and `ADM_shutdown` is never called. IMVHO, this functionality should be either fixed or the checkbox removed / hidden to avoid user confusion.