### PR TITLE
[crashdump] Add missing newline after file name

### DIFF
--- a/avidemux_core/ADM_core/src/ADM_crashdump_mingw.cpp
+++ b/avidemux_core/ADM_core/src/ADM_crashdump_mingw.cpp
@@ -376,6 +376,6 @@ LONG WINAPI TopLevelExceptionHandler(struct _EXCEPTION_POINTERS *exceptionInfo)
 void ADM_backTrack(const char *info, int lineno, const char *file)
 {	
     char title[2048]={0};
-        snprintf(title,2000,"%s at line %d, file %s",info,lineno,file);
+        snprintf(title,2000,"%s at line %d, file %s\n",info,lineno,file);
 	HandleException(title,NULL, NULL);
 }

--- a/avidemux_core/ADM_core/src/ADM_crashdump_unix.cpp
+++ b/avidemux_core/ADM_core/src/ADM_crashdump_unix.cpp
@@ -200,7 +200,7 @@ void ADM_backTrack(const char *info,int lineno,const char *file)
 
 	count = backtrace(stack, MAX_BACKTRACK);
 	functions = backtrace_symbols(stack, count);
-	sprintf(wholeStuff,"%s\n at line %d, file %s",info,lineno,file);
+	sprintf(wholeStuff,"%s\n at line %d, file %s\n",info,lineno,file);
         int status;
         size_t size=2047;
     // it looks like that xxxx (functionName+0x***) XXXX

--- a/avidemux_core/ADM_core/src/ADM_debug.cpp
+++ b/avidemux_core/ADM_core/src/ADM_debug.cpp
@@ -48,7 +48,7 @@ static void ADM_prettyPrint(const char *func,const char *color, const char *p)
 #if _WIN32
       printf("[%s] %02d:%02d:%02d-%03d %s", func, (int)hh,(int)mn,(int)seconds,(int)mseconds,p);
 #else
-    printf("%s [%s] %02d:%02d:%02d-%03d  %s %s",color,func,(int)hh,(int)mn,(int)seconds,(int)mseconds,p,ADM_DEFAULT_COLOR);
+    printf("%s [%s] %02d:%02d:%02d-%03d  %s%s",color,func,(int)hh,(int)mn,(int)seconds,(int)mseconds,p,ADM_DEFAULT_COLOR);
 #endif
 }
 


### PR DESCRIPTION
I crashed Avidemux too often to further ignore this merely cosmetical omission in the output of `ADM_backTrack` for Linux and MinGW (the Apple version of the function has its trailing newline).