### PR TITLE
[encoding] Move pass 1 encoding dialog to muxer, reuse it for pass 2

### DIFF
--- a/avidemux/common/gui_savenew.cpp
+++ b/avidemux/common/gui_savenew.cpp
@@ -192,7 +192,7 @@ bool abort=false;
             return NULL;
         }
         muxer->createUI(videoDuration);
-        muxer->encoding->setPhasis("Pass 1"); // don't make it translatable here, this is done in the encoding dialog
+        muxer->getEncoding()->setPhasis("Pass 1"); // don't make it translatable here, this is done in the encoding dialog
 
         ADMBitstream bitstream;
         uint8_t *buffer=new uint8_t[BUFFER_SIZE];
@@ -210,12 +210,12 @@ bool abort=false;
                 uint32_t p=(uint32_t)f;
                 if(percent<p)
                     percent=p; // avoid progress bar going backwards
-                if(!muxer->encoding->isAlive())
+                if(!muxer->getEncoding()->isAlive())
                 {
                     abort=true;
                     break;
                 }
-                muxer->encoding->setPercent(percent);
+                muxer->getEncoding()->setPercent(percent);
                 uint32_t elapsed=ticktock.getElapsedMS();
                 if(percent>=1)
                 {
@@ -224,7 +224,7 @@ bool abort=false;
                     if(remaining<0)
                         remaining=0;
                     uint32_t remainingMs=(uint32_t)remaining;
-                    muxer->encoding->setRemainingTimeMS(remainingMs);
+                    muxer->getEncoding()->setRemainingTimeMS(remainingMs);
                 }
             }
             nbFrames++;

--- a/avidemux_core/ADM_coreMuxer/include/ADM_muxer.h
+++ b/avidemux_core/ADM_coreMuxer/include/ADM_muxer.h
@@ -57,11 +57,13 @@ protected:
 
                 uint64_t videoIncrement; // Used/set by initUI
                 uint64_t videoDuration;
-                DIA_encodingBase  *encoding;
-                
+
 public:
                           ADM_muxer() {vStream=NULL;aStreams=NULL;nbAStreams=0;encoding=NULL;};
         virtual           ~ADM_muxer() {closeUI();};
+
+        DIA_encodingBase  *encoding;
+
         virtual bool      open(const char *filename,   ADM_videoStream *videoStream,
                                 uint32_t nbAudioTrack, ADM_audioStream **audioStreams)=0;
 
@@ -69,6 +71,7 @@ public:
         virtual  bool     close(void)=0; 
         
         virtual  bool     initUI(const char *title);
+        virtual  bool     createUI(uint64_t duration);
         virtual  bool     updateUI(void);
         virtual  bool     closeUI(void);
         virtual  bool     useGlobalHeader(void) {return false;}

--- a/avidemux_core/ADM_coreMuxer/include/ADM_muxer.h
+++ b/avidemux_core/ADM_coreMuxer/include/ADM_muxer.h
@@ -57,19 +57,17 @@ protected:
 
                 uint64_t videoIncrement; // Used/set by initUI
                 uint64_t videoDuration;
+                DIA_encodingBase *encoding;
 
 public:
                           ADM_muxer() {vStream=NULL;aStreams=NULL;nbAStreams=0;encoding=NULL;};
         virtual           ~ADM_muxer() {closeUI();};
-
-        DIA_encodingBase  *encoding;
-
         virtual bool      open(const char *filename,   ADM_videoStream *videoStream,
                                 uint32_t nbAudioTrack, ADM_audioStream **audioStreams)=0;
 
         virtual  bool     save(void)=0;
         virtual  bool     close(void)=0; 
-        
+        virtual  DIA_encodingBase *getEncoding(void) { return encoding; };
         virtual  bool     initUI(const char *title);
         virtual  bool     createUI(uint64_t duration);
         virtual  bool     updateUI(void);

--- a/avidemux_core/ADM_coreMuxer/src/ADM_muxerUtils.cpp
+++ b/avidemux_core/ADM_coreMuxer/src/ADM_muxerUtils.cpp
@@ -18,7 +18,6 @@
 #include "ADM_muxerUtils.h"
 #include "fourcc.h"
 #include "ADM_vidMisc.h"
-#include "prefs.h"
 
 /**
     \fn rescaleFps
@@ -75,8 +74,11 @@ bool     ADM_muxer::initUI(const char *title)
 {
         videoIncrement=vStream->getFrameIncrement();  // Video increment in AVI-Tick
         videoDuration=vStream->getVideoDuration();
-        ADM_info("Muxer, creating UI, video duration is %s\n",ADM_us2plain(videoDuration));
-        encoding=createEncoding(videoDuration);
+        if(!encoding)
+        {
+            ADM_info("Muxer, creating UI, video duration is %s\n",ADM_us2plain(videoDuration));
+            createUI(videoDuration);
+        }
         // Set video stream etc...
         encoding->setPhasis(title);
         encoding->setVideoCodec(fourCC::tostring(vStream->getFCC()));
@@ -85,6 +87,17 @@ bool     ADM_muxer::initUI(const char *title)
                 else    encoding->setAudioCodec(getStrFromAudioCodec(aStreams[0]->getInfo()->encoding));
         return true;
 }
+
+/**
+    \fn createUI
+    \brief create an encoding dialog / progress indicator
+*/
+bool ADM_muxer::createUI(uint64_t duration)
+{
+    encoding=createEncoding(duration);
+    return true;
+}
+
 /**
         \fn updateUI
         \brief Update the progress bar


### PR DESCRIPTION
This patch circumvents difficulties of sharing the encoding dialog between different parts of the application by managing it solely from the core muxer and also cleans up a few includes.

Now it is possible to send Avidemux during the first pass to tray and it will stay there until the second pass is completed.