### PR TITLE
[UI] Enable or disable menu items dynamically

### DIFF
--- a/avidemux/common/ADM_editor/include/ADM_edit.hxx
+++ b/avidemux/common/ADM_editor/include/ADM_edit.hxx
@@ -196,6 +196,7 @@ virtual                         ~ADM_Composer();
                     bool        copyToClipBoard(uint64_t startTime, uint64_t endTime);
                     bool        pasteFromClipBoard(uint64_t currentTime);
                     bool        appendFromClipBoard(void);
+                    bool        clipboardEmpty(void);
                     bool     	addFile (const char *name);
 					int         appendFile(const char *name);
 					void		closeFile(void);
@@ -226,11 +227,15 @@ typedef std::vector <undoQueueElem> ListOfUndoQueueElements;
 
 protected:
                     ListOfUndoQueueElements undoQueue;
+                    static const uint8_t maxUndoSteps=50;
+                    uint32_t    _cnt; // track the nb of performed undo steps for redo
 public:
                     bool        addToUndoQueue(void);
                     bool        undo(void);
                     bool        redo(void);
                     bool        clearUndoQueue(void);
+                    bool        canUndo(void);
+                    bool        canRedo(void);
 /************************************ Public API ***************************/
 public:
                     uint64_t    getLastKeyFramePts(void);

--- a/avidemux/common/ADM_editor/include/ADM_segment.h
+++ b/avidemux/common/ADM_editor/include/ADM_segment.h
@@ -198,6 +198,7 @@ public:
             bool        pasteFromClipBoard(uint64_t currentTime);
             bool        appendFromClipBoard(void);
             bool        dumpClipBoard();
+            bool        clipboardEmpty(void);
 protected:
             void        dumpSegmentsInternal(ListOfSegments &l);
 };

--- a/avidemux/common/ADM_editor/src/ADM_edit.cpp
+++ b/avidemux/common/ADM_editor/src/ADM_edit.cpp
@@ -89,7 +89,14 @@ bool ADM_Composer::appendFromClipBoard(void)
 {
     return _segments.appendFromClipBoard();
 }
-
+/**
+    \fn clipboardEmpty
+    \brief Return true if we have nothing to paste or append
+*/
+bool ADM_Composer::clipboardEmpty(void)
+{
+    return _segments.clipboardEmpty();
+}
 /**
     \fn resetSeg
     \brief Redo a 1:1 mapping between ref video and segment

--- a/avidemux/common/ADM_editor/src/ADM_segment.cpp
+++ b/avidemux/common/ADM_editor/src/ADM_segment.cpp
@@ -894,7 +894,7 @@ bool        ADM_EditorSegment::dumpClipBoard()
  */
 bool        ADM_EditorSegment::pasteFromClipBoard(uint64_t currentTime)
 {
-    if(!clipboard.size())
+    if(clipboardEmpty())
     {
         ADM_info("The clipboard is empty, nothing to do\n");
         return true;
@@ -946,7 +946,7 @@ bool        ADM_EditorSegment::pasteFromClipBoard(uint64_t currentTime)
  */
 bool ADM_EditorSegment::appendFromClipBoard(void)
 {
-    if(!clipboard.size())
+    if(clipboardEmpty())
     {
         ADM_info("The clipboard is empty, nothing to do\n");
         return true;
@@ -957,6 +957,16 @@ bool ADM_EditorSegment::appendFromClipBoard(void)
     updateStartTime();
     dump();
     return true;
+}
+
+/**
+ * \fn clipboardEmpty
+ */
+bool ADM_EditorSegment::clipboardEmpty(void)
+{
+    if(!clipboard.size())
+        return true;
+    return false;
 }
 
 //EOF

--- a/avidemux/common/ADM_editor/src/utils/ADM_edUndoQueue.cpp
+++ b/avidemux/common/ADM_editor/src/utils/ADM_edUndoQueue.cpp
@@ -17,9 +17,6 @@
 #include "ADM_segment.h"
 #include "ADM_edit.hxx"
 
-static const uint8_t maxUndoSteps=50;
-uint32_t _cnt; // track the nb of performed undo steps for redo
-
 /**
     \fn addToUndoQueue
     \brief stores the segment layout and markers in the undo queue
@@ -66,7 +63,7 @@ bool ADM_Composer::addToUndoQueue(void)
 
 bool ADM_Composer::undo(void)
 {
-    if(undoQueue.empty() || undoQueue.size()<_cnt+1)
+    if(!canUndo())
     {
         ADM_info("The undo queue is empty, nothing to do\n");
         return false;
@@ -94,7 +91,7 @@ bool ADM_Composer::undo(void)
 
 bool ADM_Composer::redo(void)
 {
-    if(_cnt<2 || undoQueue.size()<_cnt) // _cnt=2 once the first undo operation has been performed
+    if(!canRedo())
     {
         ADM_info("The redo queue is empty, cannot perform redo\n");
         return false;
@@ -115,6 +112,28 @@ bool ADM_Composer::redo(void)
 bool ADM_Composer::clearUndoQueue(void)
 {
     undoQueue.clear();
+    return true;
+}
+
+/**
+    \fn canUndo
+*/
+
+bool ADM_Composer::canUndo(void)
+{
+    if(undoQueue.empty() || undoQueue.size()<_cnt+1)
+        return false;
+    return true;
+}
+
+/**
+    \fn canRedo
+*/
+
+bool ADM_Composer::canRedo(void)
+{
+    if(_cnt<2 || undoQueue.size()<_cnt) // _cnt=2 once the first undo operation has been performed
+        return false;
     return true;
 }
 //EOF

--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
@@ -436,6 +436,7 @@ MainWindow::MainWindow(const vector<IScriptEngine*>& scriptEngines) : _scriptEng
     buildMyMenu();
     buildCustomMenu();
     // Crash in some cases addScriptReferencesToHelpMenu();
+    setMenuItemsEnabledState();
 
     QString rFiles=QString::fromUtf8(QT_TRANSLATE_NOOP("qgui2","Recent Files"));
     QString rProjects=QString::fromUtf8(QT_TRANSLATE_NOOP("qgui2","Recent Projects"));
@@ -598,6 +599,71 @@ bool MainWindow::buildMyMenu(void)
 
     return true;
 }
+
+/**
+    \fn setMenuItemsEnabledState
+    \brief disable or enable some of the menu items
+*/
+void MainWindow::setMenuItemsEnabledState(void)
+{
+    bool vid=false, undo=false, redo=false, paste=false;
+    if(video_body->getVideoDuration())
+        vid=true; // a video is loaded
+
+    ui.menuFile->actions().at(1)->setEnabled(vid); // "Append"
+    ui.menuFile->actions().at(2)->setEnabled(vid); // "Save"
+    ui.menuFile->actions().at(3)->setEnabled(vid); // "Queue"
+    ui.menuFile->actions().at(4)->setEnabled(vid); // "Save as Image" submenu
+    ui.menuFile->actions().at(5)->setEnabled(vid); // "Close"
+    ui.menuFile->actions().at(9)->setEnabled(vid); // "Information"
+
+    ui.toolBar->actions().at(2)->setEnabled(vid); // "Save" button in the toolbar
+    ui.toolBar->actions().at(3)->setEnabled(vid); // "Information" button in the toolbar
+
+    for(int i=1;i<ui.menuView->actions().size();i++)
+    { // disable zoom if no video is loaded
+        ui.menuView->actions().at(i)->setEnabled(vid);
+    }
+    if(vid)
+    {
+        undo=video_body->canUndo();
+        redo=video_body->canRedo();
+        paste=1-(video_body->clipboardEmpty());
+    }
+    ui.menuEdit->actions().at(0)->setEnabled(undo); // menu item "Undo"
+    ui.menuEdit->actions().at(1)->setEnabled(redo); // menu item "Redo"
+    if(!vid || (!undo && !redo)) // if no edits have been performed, disable "Reset Edit" menu item
+    {
+        ui.menuEdit->actions().at(2)->setEnabled(false);
+    }else
+    {
+        ui.menuEdit->actions().at(2)->setEnabled(true);
+    }
+    ui.menuEdit->actions().at(3)->setEnabled(vid); // "Cut", this doesn't catch the case of cutting the entire video
+    ui.menuEdit->actions().at(4)->setEnabled(vid); // "Copy"
+    ui.menuEdit->actions().at(5)->setEnabled(paste); // "Paste"
+    ui.menuEdit->actions().at(6)->setEnabled(vid); // "Delete"
+    ui.menuEdit->actions().at(8)->setEnabled(vid); // marker A
+    ui.menuEdit->actions().at(9)->setEnabled(vid); // marker B
+    ui.menuEdit->actions().at(10)->setEnabled(vid); // reset markers
+    for(int i=0;i<ui.menuVideo->actions().size();i++)
+    {
+        ui.menuVideo->actions().at(i)->setEnabled(vid);
+    }
+    for(int i=0;i<ui.menuAudio->actions().size();i++)
+    {
+        ui.menuAudio->actions().at(i)->setEnabled(vid);
+    }
+    for(int i=0;i<ui.menuAuto->actions().size();i++)
+    {
+        ui.menuAuto->actions().at(i)->setEnabled(vid);
+    }
+    for(int i=0;i<ui.menuGo->actions().size();i++)
+    {
+        ui.menuGo->actions().at(i)->setEnabled(vid);
+    }
+}
+
 /**
  * \fn checkChanged
  * \brief the checkbox protecting timeshift value has changed

--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.h
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.h
@@ -117,6 +117,7 @@ public slots:
         void actionSlot(Action a)
         {
             HandleAction(a);
+            setMenuItemsEnabledState();
         }
         void sendAction(Action a)
         {
@@ -127,6 +128,7 @@ public slots:
         void checkChanged(int);
 	void buttonPressed(void);
 	void toolButtonPressed(bool z);
+	void setMenuItemsEnabledState(void);
 
 	void comboChanged(int z);
 	void sliderValueChanged(int u);


### PR DESCRIPTION
This patch cleans up the undo queue a bit, getting rid of global variables and providing necessary helper functions used to determine whether a particular menu item should be enabled or disabled. Disabling e.g. the items in the "Auto" menu avoids Avidemux crashing when selecting any of the items without a video loaded.

Disabling the "Save as Image" submenu instead of the submenu actions is clumsy, but I haven't found a solution for that during the time available.