### PR TITLE
[GUI_avsProxy] Return when called during playback, avoid crash

### DIFF
--- a/avidemux/common/gui_main.cpp
+++ b/avidemux/common/gui_main.cpp
@@ -1493,6 +1493,8 @@ uint8_t GUI_close(void)
 
 void GUI_avsProxy(void)
 {
+  if(playing)
+      return;
   uint8_t res;
 
 


### PR DESCRIPTION
Despite the "connect to avsproxy" menu item getting disabled during playback if [https://github.com/mean00/avidemux2/pull/110](https://github.com/mean00/avidemux2/pull/110) gets merged, this is probably not wrong to additionally safeguard against the crash when trying to connect to avsproxy while playing.