### PR TITLE
[polish] Hide the dummy VuMeter OpenGL widget after probing

### DIFF
--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2GL.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2GL.cpp
@@ -79,6 +79,8 @@ void UI_Qt4InitGl(void)
 	printf("[GL Render] OpenGL Version: %s\n", glGetString(GL_VERSION));
 	printf("[GL Render] OpenGL Extensions: %s\n", glGetString(GL_EXTENSIONS));
 
+    topGlWidgetRoot->hide();
+
 }
 /**
     \fn UI_Qt4CleanGl


### PR DESCRIPTION
That small black square of the dummy GL widget at the left top corner of the vumeter looks out of place. It seems like it could be hidden without adverse effects once the probing of OpenGL capabilities has been completed.