### PR TITLE
[UI] Fix menus not enabled if video was loaded on command line

### DIFF
--- a/avidemux/common/gui_main.cpp
+++ b/avidemux/common/gui_main.cpp
@@ -778,8 +778,8 @@ int A_openVideo (const char *name)
 #endif
         /* remember any video or workbench file to "recent" */
         prefs->set_lastfile(longname);
-        UI_updateRecentMenu();
         updateLoaded();
+        UI_updateRecentMenu();
         if(video_body->getNumberOfActiveAudioTracks())
             audioCodecSetByIndex(0,ac); // try to preserve audio codec
         if (currentaudiostream)

--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
@@ -436,7 +436,6 @@ MainWindow::MainWindow(const vector<IScriptEngine*>& scriptEngines) : _scriptEng
     buildMyMenu();
     buildCustomMenu();
     // Crash in some cases addScriptReferencesToHelpMenu();
-    setMenuItemsEnabledState();
 
     QString rFiles=QString::fromUtf8(QT_TRANSLATE_NOOP("qgui2","Recent Files"));
     QString rProjects=QString::fromUtf8(QT_TRANSLATE_NOOP("qgui2","Recent Projects"));
@@ -886,7 +885,6 @@ bool MainWindow::eventFilter(QObject* watched, QEvent* event)
             break;
         case QEvent::User:
             this->openFiles(((FileDropEvent*)event)->files);
-            setMenuItemsEnabledState();
             break;
         default:
             break;
@@ -1252,6 +1250,7 @@ Action searchTranslationTable(const char *name)
 void UI_updateRecentMenu( void )
 {
     ((MainWindow *)QuiMainWindows)->buildRecentMenu();
+    ((MainWindow *)QuiMainWindows)->setMenuItemsEnabledState();
 }
 
 void UI_updateRecentProjectMenu()


### PR DESCRIPTION
This patch fixes enabling menus on video load universally, hooking `setMenuItemsEnabledState()` through `UI_updateRecentMenu()` and reversing the order of calls in `A_openVideo` for that purpose. The patch obsoletes and reverts also the part of the previous patch dedicated to the issue with drag'n'drop (which placed the call at a wrong place, by the way – the right one would have been in the body of `MainWindow::openFiles` if the test for `avifileinfo` fails)