### PR TITLE
[Qt] Fix regressions concerning menu items enabling and disabling

### DIFF
--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
@@ -596,7 +596,6 @@ bool MainWindow::buildMyMenu(void)
     connect( ui.menuView,SIGNAL(triggered(QAction*)),this,SLOT(searchViewMenu(QAction*)));
     buildMenu(ui.menuView, &myMenuView[0], myMenuView.size());
 
-    
     // Make a list of the items that are enabled/disabled depending if video is loaded or  not
     //-----------------------------------------------------------------------------------
     for(int i=1;i<6;i++)
@@ -610,45 +609,55 @@ bool MainWindow::buildMyMenu(void)
         ActionsAvailableWhenFileLoaded.push_back(ui.menuView->actions().at(i));
     }
 
+    for(int i=2;i<ui.toolBar->actions().size();i++)
+    { // disable "Save" and "Information" buttons in the toolbar if no video is loaded
+        ActionsAvailableWhenFileLoaded.push_back(ui.toolBar->actions().at(i));
+    }
+
+    for(int i=1;i<ui.menuView->actions().size();i++)
+    { // allow hiding widgets during playback
+        ActionsDisabledOnPlayback.push_back(ui.menuView->actions().at(i));
+    }
+
+    for(int i=1;i<ui.menuGo->actions().size();i++)
+    { // let "Play/Stop" stay enabled during playback
+        ActionsDisabledOnPlayback.push_back(ui.menuGo->actions().at(i));
+    }
+
 #define PUSH_FULL_MENU_LOADED(x,tailOffset)  for(int i=0;i<x.size()-tailOffset;i++)        ActionsAvailableWhenFileLoaded.push_back(x.at(i));
 #define PUSH_FULL_MENU_PLAYBACK(x,tailOffset)  for(int i=0;i<x.size()-tailOffset;i++)        ActionsDisabledOnPlayback.push_back(x.at(i));
     
-    
     for(int i=3;i<11;i++)
     { 
-        if(i==7 || i==5) continue;
+        if(i==5 || i==7 || i==11 || i==13) continue;
         ActionsAvailableWhenFileLoaded.push_back(ui.menuEdit->actions().at(i));
     }
 
-#define PUSH_FULL_MENU_LOAD
     PUSH_FULL_MENU_LOADED(ui.menuVideo->actions(),0)
     PUSH_FULL_MENU_LOADED(ui.menuAudio->actions(),0)
     PUSH_FULL_MENU_LOADED(ui.menuGo->actions(),0)
-    PUSH_FULL_MENU_LOADED(ui.menuAudio->actions(),0)
     // Item disabled on playback
     PUSH_FULL_MENU_PLAYBACK(ui.menuFile->actions(),1)
     PUSH_FULL_MENU_PLAYBACK(ui.menuEdit->actions(),0)
-    PUSH_FULL_MENU_PLAYBACK(ui.menuView->actions(),0)            
     PUSH_FULL_MENU_PLAYBACK(ui.menuVideo->actions(),0)            
     PUSH_FULL_MENU_PLAYBACK(ui.menuAudio->actions(),0)            
-    PUSH_FULL_MENU_PLAYBACK(ui.menuAuto->actions(),0)            
-    PUSH_FULL_MENU_PLAYBACK(ui.menuGo->actions(),0)            
     PUSH_FULL_MENU_PLAYBACK(ui.menuHelp->actions(),0)                        
     PUSH_FULL_MENU_PLAYBACK(ui.toolBar->actions(),0)                        
-    
+
+    // "Always available" below doesn't override the list of menu items disabled during playback
+
 #define PUSH_ALWAYS_AVAILABLE(menu,entry)   ActionsAlwaysAvailable.push_back( ui.menu->actions().at(entry));
-    
+
     PUSH_ALWAYS_AVAILABLE(menuFile,0)
     PUSH_ALWAYS_AVAILABLE(menuFile,7)
     PUSH_ALWAYS_AVAILABLE(menuFile,11)
 
-    
     PUSH_ALWAYS_AVAILABLE(menuEdit,12)
     PUSH_ALWAYS_AVAILABLE(menuEdit,14)
     PUSH_ALWAYS_AVAILABLE(menuEdit,15)            
-            
+
     ActionsAlwaysAvailable.push_back(ui.toolBar->actions().at(1));
-            
+
     return true;
 }
 
@@ -673,7 +682,6 @@ void MainWindow::setMenuItemsEnabledState(void)
     int n=ActionsAvailableWhenFileLoaded.size();
     for(int i=0;i<n;i++)
             ActionsAvailableWhenFileLoaded[i]->setEnabled(vid);
-    
  
     if(vid)
     {
@@ -691,11 +699,11 @@ void MainWindow::setMenuItemsEnabledState(void)
         ui.menuEdit->actions().at(2)->setEnabled(true);
     }
     ui.menuEdit->actions().at(5)->setEnabled(paste); // "Paste"
-    
+
     n=ActionsAlwaysAvailable.size();
     for(int i=0;i<n;i++)
         ActionsAlwaysAvailable[i]->setEnabled(true);
-    
+
 }
 
 /**

--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2_menu.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2_menu.cpp
@@ -212,6 +212,12 @@ void MainWindow::buildCustomMenu(void)
 
     this->addScriptDirToMenu(ui.menuCustom, ADM_getCustomDir(), fileExts);
     this->addScriptDirToMenu(ui.menuAuto, ADM_getAutoDir(), fileExts);
+
+#define PUSH_FULL_MENU_LOADED(x,tailOffset)  for(int i=0;i<x.size()-tailOffset;i++)        ActionsAvailableWhenFileLoaded.push_back(x.at(i));
+#define PUSH_FULL_MENU_PLAYBACK(x,tailOffset)  for(int i=0;i<x.size()-tailOffset;i++)        ActionsDisabledOnPlayback.push_back(x.at(i));
+
+    PUSH_FULL_MENU_LOADED(ui.menuAuto->actions(),0)
+    PUSH_FULL_MENU_PLAYBACK(ui.menuAuto->actions(),0)
 }
 
 void MainWindow::buildRecentMenu(QMenu *menu, std::vector<std::string>files, QAction **actions)

--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2_menu.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2_menu.cpp
@@ -213,11 +213,11 @@ void MainWindow::buildCustomMenu(void)
     this->addScriptDirToMenu(ui.menuCustom, ADM_getCustomDir(), fileExts);
     this->addScriptDirToMenu(ui.menuAuto, ADM_getAutoDir(), fileExts);
 
-#define PUSH_FULL_MENU_LOADED(x,tailOffset)  for(int i=0;i<x.size()-tailOffset;i++)        ActionsAvailableWhenFileLoaded.push_back(x.at(i));
-#define PUSH_FULL_MENU_PLAYBACK(x,tailOffset)  for(int i=0;i<x.size()-tailOffset;i++)        ActionsDisabledOnPlayback.push_back(x.at(i));
-
-    PUSH_FULL_MENU_LOADED(ui.menuAuto->actions(),0)
-    PUSH_FULL_MENU_PLAYBACK(ui.menuAuto->actions(),0)
+    for(int i=0;i<ui.menuAuto->actions().size();i++)
+    {
+        ActionsAvailableWhenFileLoaded.push_back(ui.menuAuto->actions().at(i));
+        ActionsDisabledOnPlayback.push_back(ui.menuAuto->actions().at(i));
+    }
 }
 
 void MainWindow::buildRecentMenu(QMenu *menu, std::vector<std::string>files, QAction **actions)


### PR DESCRIPTION
This patch fixes hopefully all the regressions resulting from the recent beautification and simplification of the `MainWindow::setMenuItemsEnabledState` haystack along with some cosmetic whitespace changes and a couple of comments clarifying my own misleading wording ;-)