### PR TITLE
[UI] Update shortcuts at runtime, bundle populating of action lists in a separate function

### DIFF
--- a/avidemux/cli/ADM_userInterfaces/ADM_gui2/gui_none.cpp
+++ b/avidemux/cli/ADM_userInterfaces/ADM_gui2/gui_none.cpp
@@ -60,6 +60,9 @@ void UI_setVProcessToggleStatus( uint8_t status )
 //**************************************************
 void UI_refreshCustomMenu(void) {}
 
+void UI_updateActionShortcuts(void)
+{}
+
 int    UI_getCurrentPreview(void)
 {
   return 0; 

--- a/avidemux/common/ADM_commonUI/GUI_ui.h
+++ b/avidemux/common/ADM_commonUI/GUI_ui.h
@@ -45,6 +45,7 @@ uint8_t UI_arrow_enabled(void);
 uint8_t UI_arrow_disabled(void);
 
 void UI_refreshCustomMenu(void);
+void UI_updateActionShortcuts(void);
 
 bool UI_setVUMeter( uint32_t volume[6]); // Volume between 0 and 255.
 bool UI_setDecoderName(const char *name);

--- a/avidemux/common/gui_main.cpp
+++ b/avidemux/common/gui_main.cpp
@@ -297,6 +297,7 @@ void HandleAction (Action action)
         {
             ADM_info("Saving prefs\n");
             prefs->save ();
+            UI_updateActionShortcuts();
         }
         return;
     case ACT_SavePref:

--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
@@ -474,6 +474,8 @@ MainWindow::MainWindow(const vector<IScriptEngine*>& scriptEngines) : _scriptEng
     ui.volumeWidget->setTitleBarWidget(dummy3);
     ui.audioMetreWidget->setTitleBarWidget(dummy4);
 
+    widgetsUpdateTooltips();
+
     this->adjustSize();
         QuiTaskBarProgress=createADMTaskBarProgress();
 }
@@ -832,6 +834,74 @@ void MainWindow::updateActionShortcuts(void)
             a->setShortcut(s);
         }
     }
+
+    widgetsUpdateTooltips();
+
+}
+
+/**
+    \fn widgetsUpdateTooltips
+    \brief Update tooltips showing tunable action shortcuts in the navigation and selection widgets
+*/
+void MainWindow::widgetsUpdateTooltips(void)
+{
+    std::vector<QString> ListOfShortcuts;
+    for(int i=0;i<12;i++)
+    {
+        if(i==5 || i==6 || i==9) continue;
+        QKeySequence seq=ui.menuGo->actions().at(i)->shortcut();
+        QString s=seq.toString().toUpper();
+        ListOfShortcuts.push_back(s);
+    }
+
+    for(int i=8;i<10;i++)
+    {
+        QKeySequence seq=ui.menuEdit->actions().at(i)->shortcut();
+        QString s=seq.toString().toUpper();
+        ListOfShortcuts.push_back(s);
+    }
+
+    QString tt;
+
+    tt=QString(QT_TRANSLATE_NOOP("qgui2","Play/Stop"))+QString(" [")+ListOfShortcuts[0]+QString("]");
+    ui.toolButtonPlay->setToolTip(tt);
+
+    tt=QString(QT_TRANSLATE_NOOP("qgui2","Stop"))+QString(" [")+ListOfShortcuts[0]+QString("]");
+    ui.toolButtonStop->setToolTip(tt);
+
+    tt=QString(QT_TRANSLATE_NOOP("qgui2","Go to previous frame"))+QString(" [")+ListOfShortcuts[1]+QString("]");
+    ui.toolButtonPreviousFrame->setToolTip(tt);
+
+    tt=QString(QT_TRANSLATE_NOOP("qgui2","Go to next frame"))+QString(" [")+ListOfShortcuts[2]+QString("]");
+    ui.toolButtonNextFrame->setToolTip(tt);
+
+    tt=QString(QT_TRANSLATE_NOOP("qgui2","Go to previous keyframe"))+QString(" [")+ListOfShortcuts[3]+QString("]");
+    ui.toolButtonPreviousIntraFrame->setToolTip(tt);
+
+    tt=QString(QT_TRANSLATE_NOOP("qgui2","Go to next keyframe"))+QString(" [")+ListOfShortcuts[4]+QString("]");
+    ui.toolButtonNextIntraFrame->setToolTip(tt);
+
+    tt=QString(QT_TRANSLATE_NOOP("qgui2","Set start marker"))+QString(" [")+ListOfShortcuts[9]+QString("]");
+    ui.toolButtonSetMarkerA->setToolTip(tt);
+
+    tt=QString(QT_TRANSLATE_NOOP("qgui2","Set end marker"))+QString(" [")+ListOfShortcuts[10]+QString("]");
+    ui.toolButtonSetMarkerB->setToolTip(tt);
+
+    // go to black frame tooltips are static, the actions don't have shortcuts
+
+    tt=QString(QT_TRANSLATE_NOOP("qgui2","Go to first frame"))+QString(" [")+ListOfShortcuts[5]+QString("]");
+    ui.toolButtonFirstFrame->setToolTip(tt);
+
+    tt=QString(QT_TRANSLATE_NOOP("qgui2","Go to last frame"))+QString(" [")+ListOfShortcuts[6]+QString("]");
+    ui.toolButtonLastFrame->setToolTip(tt);
+
+    // 1 minute back and forward buttons' tooltips are static, the action shortcuts are not tunable and not defined via myOwnMenu.h
+
+    tt=QString(QT_TRANSLATE_NOOP("qgui2","Go to marker A"))+QString(" [")+ListOfShortcuts[7]+QString("]");
+    ui.pushButtonJumpToMarkerA->setToolTip(tt);
+
+    tt=QString(QT_TRANSLATE_NOOP("qgui2","Go to marker B"))+QString(" [")+ListOfShortcuts[8]+QString("]");
+    ui.pushButtonJumpToMarkerB->setToolTip(tt);
 }
 
 /**

--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.h
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.h
@@ -196,6 +196,7 @@ protected:
         bool buildMenu(QMenu *root,MenuEntry *menu, int nb);
 	void buildRecentMenu(QMenu *menu,std::vector<std::string>files, QAction **actions);
         void buildActionLists(void);
+        void widgetsUpdateTooltips(void);
         void searchMenu(QAction * action,MenuEntry *menu, int nb);
 	void searchRecentFiles(QAction *action, QAction **actionList, int firstEventId);
 #ifdef   ENABLE_EVENT_FILTER      

--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.h
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.h
@@ -95,6 +95,7 @@ public:
 	void buildCustomMenu(void);
 	void buildRecentMenu(void);
 	void buildRecentProjectMenu(void);
+	void updateActionShortcuts(void);
         static void updateCheckDone(int version, const std::string &date, const std::string &downloadLink);
         static MainWindow *mainWindowSingleton;
 
@@ -194,6 +195,7 @@ protected:
         bool buildMyMenu(void);
         bool buildMenu(QMenu *root,MenuEntry *menu, int nb);
 	void buildRecentMenu(QMenu *menu,std::vector<std::string>files, QAction **actions);
+        void buildActionLists(void);
         void searchMenu(QAction * action,MenuEntry *menu, int nb);
 	void searchRecentFiles(QAction *action, QAction **actionList, int firstEventId);
 #ifdef   ENABLE_EVENT_FILTER      

--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2_menu.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2_menu.cpp
@@ -213,11 +213,6 @@ void MainWindow::buildCustomMenu(void)
     this->addScriptDirToMenu(ui.menuCustom, ADM_getCustomDir(), fileExts);
     this->addScriptDirToMenu(ui.menuAuto, ADM_getAutoDir(), fileExts);
 
-    for(int i=0;i<ui.menuAuto->actions().size();i++)
-    {
-        ActionsAvailableWhenFileLoaded.push_back(ui.menuAuto->actions().at(i));
-        ActionsDisabledOnPlayback.push_back(ui.menuAuto->actions().at(i));
-    }
 }
 
 void MainWindow::buildRecentMenu(QMenu *menu, std::vector<std::string>files, QAction **actions)


### PR DESCRIPTION
This patch implements updating the tunable action shortcuts (just these) at runtime, removing the earlier requirement to restart Avidemux for the changes to take effect.

It moves also a little bit of the menu items enabling and disabling code around, which might be helpful if we need to rebuild menus at runtime later, requiring the action lists to be recreated.