### PR TITLE
[Qt] Swap the play button icon on playback, remove the dedicated stop button

### DIFF
--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
@@ -735,7 +735,6 @@ void MainWindow::buildButtonLists(void)
 #define ADD_BUTTON_PLAYBACK(x)    ButtonsDisabledOnPlayback.push_back(ui.x);
 
     ADD_BUTTON_LOADED(toolButtonPlay)
-    ADD_BUTTON_LOADED(toolButtonStop)
     ADD_BUTTON_LOADED(toolButtonPreviousFrame)
     ADD_BUTTON_LOADED(toolButtonNextFrame)
     ADD_BUTTON_LOADED(toolButtonPreviousIntraFrame)
@@ -790,6 +789,8 @@ void MainWindow::setMenuItemsEnabledState(void)
         for(int i=0;i<ntb;i++)
             ButtonsDisabledOnPlayback[i]->setEnabled(false);
 
+        ui.toolButtonPlay->setIcon(QIcon(":/new/prefix1/pics/player_stop.png"));
+
         int npb=PushButtonsDisabledOnPlayback.size();
         for(int i=0;i<npb;i++)
             PushButtonsDisabledOnPlayback[i]->setEnabled(false);
@@ -834,6 +835,7 @@ void MainWindow::setMenuItemsEnabledState(void)
     for(int i=0;i<n;i++)
         ActionsAlwaysAvailable[i]->setEnabled(true);
 
+    ui.toolButtonPlay->setIcon(QIcon(":/new/prefix1/pics/player_play.png"));
 }
 
 /**
@@ -936,9 +938,6 @@ void MainWindow::widgetsUpdateTooltips(void)
 
     tt=QString(QT_TRANSLATE_NOOP("qgui2","Play/Stop"))+QString(" [")+ListOfShortcuts[0]+QString("]");
     ui.toolButtonPlay->setToolTip(tt);
-
-    tt=QString(QT_TRANSLATE_NOOP("qgui2","Stop"))+QString(" [")+ListOfShortcuts[0]+QString("]");
-    ui.toolButtonStop->setToolTip(tt);
 
     tt=QString(QT_TRANSLATE_NOOP("qgui2","Go to previous frame"))+QString(" [")+ListOfShortcuts[1]+QString("]");
     ui.toolButtonPreviousFrame->setToolTip(tt);

--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/gui2.ui
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/gui2.ui
@@ -986,29 +986,6 @@
           </widget>
          </item>
          <item>
-          <widget class="QToolButton" name="toolButtonStop">
-           <property name="toolTip">
-            <string>Stop [SPACE]</string>
-           </property>
-           <property name="text">
-            <string>...</string>
-           </property>
-           <property name="icon">
-            <iconset resource="avidemux.qrc">
-             <normaloff>:/new/prefix1/pics/player_stop.png</normaloff>:/new/prefix1/pics/player_stop.png</iconset>
-           </property>
-           <property name="iconSize">
-            <size>
-             <width>24</width>
-             <height>24</height>
-            </size>
-           </property>
-           <property name="autoRaise">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
           <widget class="QToolButton" name="toolButtonPreviousFrame">
            <property name="toolTip">
             <string>Go to previous frame [LEFT]</string>

--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/translation_table.h
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/translation_table.h
@@ -5,7 +5,6 @@ PROCESS(pushButtonAudioFilter, ACT_AUDIO_FILTERS) \
 PROCESS(pushButtonDecoderConf, ACT_DecoderOption) \
 PROCESS(pushButtonFormatConfigure, ACT_ContainerConfigure) \
 PROCESS(toolButtonPlay, ACT_PlayAvi) \
-PROCESS(toolButtonStop, ACT_StopAvi) \
 PROCESS(toolButtonPreviousFrame, ACT_PreviousFrame) \
 PROCESS(toolButtonNextFrame, ACT_NextFrame) \
 PROCESS(toolButtonPreviousIntraFrame, ACT_PreviousKFrame) \


### PR DESCRIPTION
This patch replaces the `player_play.png` icon on the play button with `player_stop.png` on playback, which allows to remove the somewhat redundant dedicated stop button. It doesn't replace the icon in the "Go" menu yet, this could be done in a followup patch.