### PR TITLE
[Qt] Swap the icon for play/stop on playback in the Go menu too

### DIFF
--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
@@ -790,6 +790,7 @@ void MainWindow::setMenuItemsEnabledState(void)
             ButtonsDisabledOnPlayback[i]->setEnabled(false);
 
         ui.toolButtonPlay->setIcon(QIcon(":/new/prefix1/pics/player_stop.png"));
+        ui.menuGo->actions().at(0)->setIcon(QIcon(":/new/prefix1/pics/player_stop.png"));
 
         int npb=PushButtonsDisabledOnPlayback.size();
         for(int i=0;i<npb;i++)
@@ -836,6 +837,7 @@ void MainWindow::setMenuItemsEnabledState(void)
         ActionsAlwaysAvailable[i]->setEnabled(true);
 
     ui.toolButtonPlay->setIcon(QIcon(":/new/prefix1/pics/player_play.png"));
+    ui.menuGo->actions().at(0)->setIcon(QIcon(":/new/prefix1/pics/player_play.png"));
 }
 
 /**


### PR DESCRIPTION
For the sake of consistency, this is the "Go" menu part of play/stop icon swapping which I failed to include into the previous commit. My apologies for the trouble.