### PR TITLE
[Qt] Set lastdir_read on drag'n'drop as well

### DIFF
--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
@@ -27,6 +27,7 @@
 
 #include "DIA_fileSel.h"
 #include "ADM_vidMisc.h"
+#include "ADM_last.h"
 #include "prefs.h"
 #include "avi_vars.h"
 
@@ -1228,6 +1229,11 @@ void MainWindow::openFiles(QList<QUrl> urlList)
                 A_appendVideo(fileName.toUtf8().constData());
             else
                 A_openVideo(fileName.toUtf8().constData());
+            // Set lastdir_read on drag'n'drop here instead of centrally in
+            // A_openVideo or in A_appendVideo to better deal with situations
+            // where videos are loaded from a project script in a different location.
+            // Otherwise lastdir_read is managed by the file selection dialog.
+            admCoreUtils::setLastReadFolder(std::string(fileName.toUtf8().constData()));
         }
     }
 }


### PR DESCRIPTION
This patch addresses [the following bugreport](http://avidemux.org/smif/index.php/topic,17465.msg79835.html#msg79835) by acritum.

The reason the issue is solved in Qt GUI instead of in the common Avidemux code is that managing `lastdir_read` in a centralised way in `A_openVideo` or in `A_appendVideo` while looking much more logical would result in an IMHO problematic behaviour when keeping project files and source videos in different locations: instead of opening the most recently used folder with project files, the file selection dialog would always open the folder with the last source video loaded or appended.

Loading a video via command line or ShellExecute won't update `lastdir_read`.