### PR TITLE
[UI/Qt] Hide non-functional volume widget with PulseAudioSimple

### DIFF
--- a/avidemux/cli/ADM_userInterfaces/ADM_gui2/gui_none.cpp
+++ b/avidemux/cli/ADM_userInterfaces/ADM_gui2/gui_none.cpp
@@ -60,7 +60,7 @@ void UI_setVProcessToggleStatus( uint8_t status )
 //**************************************************
 void UI_refreshCustomMenu(void) {}
 
-void UI_updateActionShortcuts(void)
+void UI_applySettings(void)
 {}
 
 int    UI_getCurrentPreview(void)

--- a/avidemux/common/ADM_commonUI/GUI_ui.h
+++ b/avidemux/common/ADM_commonUI/GUI_ui.h
@@ -45,7 +45,7 @@ uint8_t UI_arrow_enabled(void);
 uint8_t UI_arrow_disabled(void);
 
 void UI_refreshCustomMenu(void);
-void UI_updateActionShortcuts(void);
+void UI_applySettings(void);
 
 bool UI_setVUMeter( uint32_t volume[6]); // Volume between 0 and 255.
 bool UI_setDecoderName(const char *name);

--- a/avidemux/common/gui_main.cpp
+++ b/avidemux/common/gui_main.cpp
@@ -297,7 +297,7 @@ void HandleAction (Action action)
         {
             ADM_info("Saving prefs\n");
             prefs->save ();
-            UI_updateActionShortcuts();
+            UI_applySettings();
         }
         return;
     case ACT_SavePref:

--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
@@ -475,6 +475,7 @@ MainWindow::MainWindow(const vector<IScriptEngine*>& scriptEngines) : _scriptEng
     ui.audioMetreWidget->setTitleBarWidget(dummy4);
 
     widgetsUpdateTooltips();
+    volumeWidgetOperational();
 
     this->adjustSize();
         QuiTaskBarProgress=createADMTaskBarProgress();
@@ -1247,6 +1248,29 @@ void MainWindow::nextIntraFrame(void)
     else
         sendAction(ACT_NextKFrame);
 }
+
+/**
+
+*/
+void MainWindow::volumeWidgetOperational(void)
+{
+    // PulseAudioSimple doesn't provide a way to adjust volume, don't show
+    // the volume widget when it looks like it were broken
+    std::string adev;
+    prefs->get(AUDIO_DEVICE_AUDIODEVICE, adev);
+    if(adev==std::string("PulseAudioS"))
+    {
+        ui.volumeWidget->setEnabled(false);
+        ui.volumeWidget->hide();
+        ui.actionViewVolume->setChecked(false);
+    }else
+    {
+        ui.volumeWidget->setEnabled(true);
+        ui.volumeWidget->show();
+        ui.actionViewVolume->setChecked(true);
+    }
+}
+
 MainWindow::~MainWindow()
 {
     renderDestroy(); // make sure render does not have back link to us
@@ -1394,11 +1418,13 @@ void UI_refreshCustomMenu(void)
     ((MainWindow*)QuiMainWindows)->buildCustomMenu();
 }
 /**
-    \fn UI_updateActionShortcuts
+    \fn UI_applySettings
+    \brief Do stuff when closing the preferences dialog
 */
-void UI_updateActionShortcuts(void)
+void UI_applySettings(void)
 {
     ((MainWindow *)QuiMainWindows)->updateActionShortcuts();
+    ((MainWindow *)QuiMainWindows)->volumeWidgetOperational();
 }
 /**
     \fn UI_getCurrentPreview(void)

--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
@@ -98,6 +98,7 @@ QGraphicsView *drawWindow=NULL;
 
 extern void saveCrashProject(void);
 extern uint8_t AVDM_setVolume(int volume);
+extern bool AVDM_hasVolumeControl(void);
 extern bool ADM_QPreviewCleanup(void);
 extern void vdpauCleanup();
 extern bool A_loadDefaultSettings(void);;
@@ -475,7 +476,6 @@ MainWindow::MainWindow(const vector<IScriptEngine*>& scriptEngines) : _scriptEng
     ui.audioMetreWidget->setTitleBarWidget(dummy4);
 
     widgetsUpdateTooltips();
-    volumeWidgetOperational();
 
     this->adjustSize();
         QuiTaskBarProgress=createADMTaskBarProgress();
@@ -1254,11 +1254,8 @@ void MainWindow::nextIntraFrame(void)
 */
 void MainWindow::volumeWidgetOperational(void)
 {
-    // PulseAudioSimple doesn't provide a way to adjust volume, don't show
-    // the volume widget when it looks like it were broken
-    std::string adev;
-    prefs->get(AUDIO_DEVICE_AUDIODEVICE, adev);
-    if(adev==std::string("PulseAudioS"))
+    // Hide and disable the volume widget if the audio device doesn't support setting volume
+    if(!AVDM_hasVolumeControl())
     {
         ui.volumeWidget->setEnabled(false);
         ui.volumeWidget->hide();
@@ -1482,6 +1479,7 @@ int UI_RunApp(void)
     
     ADM_info("Load default settings if any... \n");          
     A_loadDefaultSettings();
+    UI_applySettings();
     
     // start update checking..
     bool autoUpdateEnabled=false;

--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.h
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.h
@@ -96,6 +96,7 @@ public:
 	void buildRecentMenu(void);
 	void buildRecentProjectMenu(void);
 	void updateActionShortcuts(void);
+        void volumeWidgetOperational(void);
         static void updateCheckDone(int version, const std::string &date, const std::string &downloadLink);
         static MainWindow *mainWindowSingleton;
 

--- a/avidemux_core/ADM_coreAudioDevice/include/ADM_audiodevice.h
+++ b/avidemux_core/ADM_coreAudioDevice/include/ADM_audiodevice.h
@@ -42,6 +42,7 @@ ADM_COREAUDIODEVICE6_EXPORT uint8_t ADM_av_loadPlugins(const char *path);
                         virtual uint8_t  stop(void)=0;
                         virtual uint8_t  play(uint32_t len, float *data) =0;
                         virtual uint8_t  setVolume(int volume) {return 1;}
+                        virtual bool     hasVolumeControl(void) {return true;}
                         virtual uint32_t getLatencyMs(void) {return 0;}
 }   ;
 
@@ -96,7 +97,8 @@ class dummyAudioDevice : public audioDeviceThreaded
 		  protected:
                     virtual     bool     localInit(void);
                     virtual     bool     localStop(void);
-                    virtual     void     sendData(void);    
+                    virtual     void     sendData(void);
+                    virtual     bool     hasVolumeControl(void) { return false; }
                     virtual const CHANNEL_TYPE *getWantedChannelMapping(uint32_t channels){return myChannelType;}
 }   ;
 

--- a/avidemux_core/ADM_coreAudioDevice/include/audio_out.h
+++ b/avidemux_core/ADM_coreAudioDevice/include/audio_out.h
@@ -34,6 +34,7 @@ ADM_COREAUDIODEVICE6_EXPORT void 		AVDM_AudioClose(void);
 ADM_COREAUDIODEVICE6_EXPORT uint32_t    AVDM_GetLayencyMs(void);
 ADM_COREAUDIODEVICE6_EXPORT AUDIO_DEVICE 	AVDM_getCurrentDevice( void);
 ADM_COREAUDIODEVICE6_EXPORT uint8_t         AVDM_setVolume(int volume);
+ADM_COREAUDIODEVICE6_EXPORT bool            AVDM_hasVolumeControl(void);
 // Get infos
 ADM_COREAUDIODEVICE6_EXPORT uint32_t    ADM_av_getNbDevices(void);
 ADM_COREAUDIODEVICE6_EXPORT bool        ADM_av_getDeviceInfo(int filter, std::string &name, uint32_t *major,uint32_t *minor,uint32_t *patch);

--- a/avidemux_core/ADM_coreAudioDevice/src/ADM_audiodevice.cpp
+++ b/avidemux_core/ADM_coreAudioDevice/src/ADM_audiodevice.cpp
@@ -256,6 +256,19 @@ uint8_t         AVDM_setVolume(int volume)
 
 }
 /**
+    \fn AVDM_hasVolumeControl
+*/
+bool AVDM_hasVolumeControl(void)
+{
+    bool r=true;
+    if(!device)
+        return false;
+    r=device->hasVolumeControl();
+    if(!r)
+        ADM_info("The current audio device doesn't support volume control\n");
+    return r;
+}
+/**
     \fn AVDM_AudioPlay
     \brief Send float data to be played immediately by the device
 

--- a/avidemux_plugins/ADM_audioDevices/PulseAudioSimple/ADM_devicePulseSimple.h
+++ b/avidemux_plugins/ADM_audioDevices/PulseAudioSimple/ADM_devicePulseSimple.h
@@ -27,7 +27,7 @@ class pulseSimpleAudioDevice : public audioDeviceThreaded
          virtual const CHANNEL_TYPE *getWantedChannelMapping(uint32_t channels);
       public:
                 pulseSimpleAudioDevice(void);
-                
+                bool     hasVolumeControl(void) { return false; }
                 uint32_t getLatencyMs(void);
      }     ;
 #endif


### PR DESCRIPTION
On Linux, we default to PulseAudioSimple output, which doesn't support volume control. Showing users a non-operational volume slider may be confusing, hide the volume widget if PulseAudioSimple is selected.

Furthermore, reinterpret `UI_updateActionShortcut` as the general way to perform actions on saving preferences, rename in to `UI_applySettings`.