### PR TITLE
[Qt] Disable context menus for menubar and toolbar

### DIFF
--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/gui2.ui
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/gui2.ui
@@ -112,6 +112,9 @@
      <height>30</height>
     </rect>
    </property>
+   <property name="contextMenuPolicy">
+    <enum>Qt::PreventContextMenu</enum>
+   </property>
    <widget class="QMenu" name="menuHelp">
     <property name="title">
      <string>&amp;Help</string>
@@ -193,6 +196,9 @@
   <widget class="QToolBar" name="toolBar">
    <property name="orientation">
     <enum>Qt::Horizontal</enum>
+   </property>
+   <property name="contextMenuPolicy">
+    <enum>Qt::PreventContextMenu</enum>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>


### PR DESCRIPTION
The context menus of the menubar and the toolbar duplicate the functionality of the "View" --> "Toolbars" menu, look a bit strange with nameless entries and are not translatable. This patch disables them for good.