### PR TITLE
[Qt] Disable items of the menu 'Recent' submenus on playback

### DIFF
--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
@@ -706,6 +706,13 @@ void MainWindow::buildActionLists(void)
     PUSH_FULL_MENU_PLAYBACK(menuHelp,0)
     PUSH_FULL_MENU_PLAYBACK(toolBar,0)
 
+    if(recentFiles)
+        for(int i=0;i<recentFiles->actions().size();i++)
+            ActionsDisabledOnPlayback.push_back(recentFiles->actions().at(i));
+    if(recentProjects)
+        for(int i=0;i<recentProjects->actions().size();i++)
+            ActionsDisabledOnPlayback.push_back(recentProjects->actions().at(i));
+
     // "Always available" below doesn't override the list of menu items disabled during playback
 
 #define PUSH_ALWAYS_AVAILABLE(menu,entry)   ActionsAlwaysAvailable.push_back( ui.menu->actions().at(entry));
@@ -720,6 +727,12 @@ void MainWindow::buildActionLists(void)
 
     PUSH_ALWAYS_AVAILABLE(toolBar,1)
 
+    if(recentFiles)
+        for(int i=0;i<recentFiles->actions().size();i++)
+            ActionsAlwaysAvailable.push_back(recentFiles->actions().at(i));
+    if(recentProjects)
+        for(int i=0;i<recentProjects->actions().size();i++)
+            ActionsAlwaysAvailable.push_back(recentProjects->actions().at(i));
 }
 
 /**

--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2_menu.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2_menu.cpp
@@ -239,11 +239,13 @@ void MainWindow::buildRecentMenu(QMenu *menu, std::vector<std::string>files, QAc
 void MainWindow::buildRecentMenu(void)
 {
 	this->buildRecentMenu(this->recentFiles, prefs->get_lastfiles(), this->recentFileAction);
+	buildActionLists();
 }
 
 void MainWindow::buildRecentProjectMenu(void)
 {
 	this->buildRecentMenu(this->recentProjects, prefs->get_lastprojectfiles(), this->recentProjectAction);
+	buildActionLists();
 }
 
 void MainWindow::searchRecentFiles(QAction *action, QAction **actionList, int firstEventId)


### PR DESCRIPTION
This is hopefully the last bit of the menu items' disabling/enabling work.