### PR TITLE
[ae_lavc] Fix max bitrate for mp2 and ac3

### DIFF
--- a/avidemux_plugins/ADM_audioEncoders/lavcodec/ADM_lav_aac.cpp
+++ b/avidemux_plugins/ADM_audioEncoders/lavcodec/ADM_lav_aac.cpp
@@ -10,5 +10,20 @@
 #define ADM_LAV_SAMPLE_PER_P 1024
 
 #define ADM_LAV_GLOBAL_HEADER 1
-#include "audioencoder_lavcodec.cpp"
 
+#define MENU_BITRATE     diaMenuEntry bitrateM[]={\
+                              BITRATE(56),\
+                              BITRATE(64),\
+                              BITRATE(80),\
+                              BITRATE(96),\
+                              BITRATE(112),\
+                              BITRATE(128),\
+                              BITRATE(160),\
+                              BITRATE(192),\
+                              BITRATE(224),\
+                              BITRATE(384),\
+                              BITRATE(448),\
+                              BITRATE(640)\
+                          };
+
+#include "audioencoder_lavcodec.cpp"

--- a/avidemux_plugins/ADM_audioEncoders/lavcodec/ADM_lav_ac3.cpp
+++ b/avidemux_plugins/ADM_audioEncoders/lavcodec/ADM_lav_ac3.cpp
@@ -9,4 +9,19 @@
 #define ADM_LAV_MAX_CHANNEL 6
 #define ADM_LAV_SAMPLE_PER_P 1536
 
+#define MENU_BITRATE     diaMenuEntry bitrateM[]={\
+                              BITRATE(56),\
+                              BITRATE(64),\
+                              BITRATE(80),\
+                              BITRATE(96),\
+                              BITRATE(112),\
+                              BITRATE(128),\
+                              BITRATE(160),\
+                              BITRATE(192),\
+                              BITRATE(224),\
+                              BITRATE(384),\
+                              BITRATE(448),\
+                              BITRATE(640)\
+                          };
+
 #include "audioencoder_lavcodec.cpp"

--- a/avidemux_plugins/ADM_audioEncoders/lavcodec/ADM_lav_dts.cpp
+++ b/avidemux_plugins/ADM_audioEncoders/lavcodec/ADM_lav_dts.cpp
@@ -9,4 +9,19 @@
 #define ADM_LAV_MAX_CHANNEL 6
 #define ADM_LAV_SAMPLE_PER_P 1536
 
+#define MENU_BITRATE     diaMenuEntry bitrateM[]={\
+                              BITRATE(56),\
+                              BITRATE(64),\
+                              BITRATE(80),\
+                              BITRATE(96),\
+                              BITRATE(112),\
+                              BITRATE(128),\
+                              BITRATE(160),\
+                              BITRATE(192),\
+                              BITRATE(224),\
+                              BITRATE(384),\
+                              BITRATE(448),\
+                              BITRATE(640)\
+                          };
+
 #include "audioencoder_lavcodec.cpp"

--- a/avidemux_plugins/ADM_audioEncoders/lavcodec/ADM_lav_mp2.cpp
+++ b/avidemux_plugins/ADM_audioEncoders/lavcodec/ADM_lav_mp2.cpp
@@ -9,5 +9,17 @@
 #define ADM_LAV_MAX_CHANNEL 6
 #define ADM_LAV_SAMPLE_PER_P 1152
 
+#define MENU_BITRATE     diaMenuEntry bitrateM[]={\
+                              BITRATE(56),\
+                              BITRATE(64),\
+                              BITRATE(80),\
+                              BITRATE(96),\
+                              BITRATE(112),\
+                              BITRATE(128),\
+                              BITRATE(160),\
+                              BITRATE(192),\
+                              BITRATE(224),\
+                              BITRATE(384)\
+                          };
 
 #include "audioencoder_lavcodec.cpp"

--- a/avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp
+++ b/avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp
@@ -514,19 +514,7 @@ bool configure (CONFcouple **setup)
         ADM_paramLoad(*setup,lav_encoder_param,&config);
     }
 
-    diaMenuEntry bitrateM[]={
-                              BITRATE(56),
-                              BITRATE(64),
-                              BITRATE(80),
-                              BITRATE(96),
-                              BITRATE(112),
-                              BITRATE(128),
-                              BITRATE(160),
-                              BITRATE(192),
-                              BITRATE(224),
-                              BITRATE(384),
-                              BITRATE(448)
-                          };
+    MENU_BITRATE
     diaElemMenu bitrate(&(config.bitrate),   QT_TRANSLATE_NOOP("lavcodec","_Bitrate:"), SZT(bitrateM),bitrateM);
 
 


### PR DESCRIPTION
Currently, the configuration dialog suggests illegal max. bitrate of 448kbps for the mp2 lavc encoder, which gets later rejected by FFmpeg. At the same time, users [want](http://avidemux.org/smif/index.php/topic,8505.msg79921.html) to be able to use an ac3 bitrate exceeding the max. bitrate allowed by the DVD spec. Disentangle both at least at the GUI level for now.