### PR TITLE
[UI] Update the number of active audio tracks when running a script

### DIFF
--- a/avidemux/common/gui_main.cpp
+++ b/avidemux/common/gui_main.cpp
@@ -245,7 +245,7 @@ void HandleAction (Action action)
 
                             ADM_assert(name[rank].size());
                             call_scriptEngine(name[rank].c_str());
-
+                            A_Resync();
                             return;
             }
     case ACT_VIDEO_CODEC_CONFIGURE:
@@ -1386,6 +1386,7 @@ void A_Resync(void)
         if(!avifileinfo) return;
         GUI_setAllFrameAndTime();
         UI_setMarkers (video_body->getMarkerAPts(),video_body->getMarkerBPts());
+        UI_setAudioTrackCount(video_body->getNumberOfActiveAudioTracks());
 }
 uint8_t  DIA_job_select(char **jobname, char **filename);
 void A_addJob(void)


### PR DESCRIPTION
One more last-minute fix, hopefully completely harmless. The reference: ["Audio Output" number of tracks (not) updating ](http://avidemux.org/smif/index.php/topic,17053.0.html).