### PR TITLE
[GUI] Set tooltips for 1min backward/forward buttons dynamically

### DIFF
--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
@@ -988,13 +988,30 @@ void MainWindow::widgetsUpdateTooltips(void)
     tt=QString(QT_TRANSLATE_NOOP("qgui2","Go to last frame"))+QString(" [")+ListOfShortcuts[6]+QString("]");
     ui.toolButtonLastFrame->setToolTip(tt);
 
-    // 1 minute back and forward buttons' tooltips are static, the action shortcuts are not tunable and not defined via myOwnMenu.h
-
     tt=QString(QT_TRANSLATE_NOOP("qgui2","Go to marker A"))+QString(" [")+ListOfShortcuts[7]+QString("]");
     ui.pushButtonJumpToMarkerA->setToolTip(tt);
 
     tt=QString(QT_TRANSLATE_NOOP("qgui2","Go to marker B"))+QString(" [")+ListOfShortcuts[8]+QString("]");
     ui.pushButtonJumpToMarkerB->setToolTip(tt);
+
+    // special case one minute back and forward buttons, their action shortcuts are not defined via myOwnMenu.h
+    bool swpud=false;
+    prefs->get(KEYBOARD_SHORTCUTS_SWAP_UP_DOWN_KEYS,&swpud);
+    QString back, forward;
+    if(!swpud)
+    {
+        back="DOWN";
+        forward="UP";
+    }else
+    {
+        back="UP";
+        forward="DOWN";
+    }
+    tt=QString(QT_TRANSLATE_NOOP("qgui2","Backward one minute"))+QString(" [CTRL+")+back+QString("]");
+    ui.toolButtonBackOneMinute->setToolTip(tt);
+
+    tt=QString(QT_TRANSLATE_NOOP("qgui2","Forward one minute"))+QString(" [CTRL+")+forward+QString("]");
+    ui.toolButtonForwardOneMinute->setToolTip(tt);
 }
 
 /**


### PR DESCRIPTION
I've missed one more big thing: the tooltips for the one minute backward and forward buttons must be set dynamically too because their respective shortcuts are swappable. This means, I'll have to regenerate translation files once again (I'll try to catch a few fleas like the NVENC h264 config dialog title before I do that).