### PR TITLE
[i18n] Regenerate .ts files again, add a few DE and RU translations, fix some translations broken by recent changes in FR and DA

### DIFF
--- a/avidemux/qt4/i18n/avidemux_ca.ts
+++ b/avidemux/qt4/i18n/avidemux_ca.ts
@@ -8314,7 +8314,7 @@ Expect problems.</source>
         <translation type="unfinished">Pista principal d&apos;àudio</translation>
     </message>
     <message>
-        <location line="+257"/>
+        <location line="+258"/>
         <source>AvsProxy</source>
         <translation type="unfinished">AvsProxy</translation>
     </message>
@@ -8433,7 +8433,7 @@ Segur que està funcionant?</translation>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_libva.cpp" line="+135"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_vdpau_utils.cpp" line="+51"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_xvba.cpp" line="+134"/>
-        <location filename="../../common/gui_main.cpp" line="-243"/>
+        <location filename="../../common/gui_main.cpp" line="-244"/>
         <location line="+27"/>
         <location line="+24"/>
         <location line="+8"/>
@@ -9229,7 +9229,7 @@ It is needed to create PSP compatible video.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+289"/>
+        <location line="+290"/>
         <source>Oops</source>
         <translation type="unfinished">Caram!</translation>
     </message>
@@ -9830,6 +9830,11 @@ Do you want to continue anyway ?</source>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_dxva2.cpp" line="+0"/>
         <source>Core has been compiled without DXVA2 support, but the application has been compiled with it.
 Installation mismatch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+246"/>
+        <source>Cannot compile shader</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12500,7 +12505,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+146"/>
         <source>Width :</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12528,7 +12533,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
+        <location line="+118"/>
         <source>Angle (°):</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12554,7 +12559,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>glShader</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+60"/>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-182"/>
         <source>Shader Loader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12564,12 +12569,12 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+164"/>
+        <location line="+192"/>
         <source>ShaderFile to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>ShaderLoader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13362,7 +13367,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>lavcodec</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+530"/>
+        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+518"/>
         <source>_Bitrate:</source>
         <translation type="unfinished">Taxa de _bits: </translation>
     </message>
@@ -14658,7 +14663,7 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+220"/>
+        <location line="+222"/>
         <source>Recent Files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14668,7 +14673,7 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished">Projectes recents</translation>
     </message>
     <message>
-        <location line="+511"/>
+        <location line="+516"/>
         <source>Play/Stop</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14713,13 +14718,23 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Go to marker A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to marker B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Backward one minute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Forward one minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -14892,7 +14907,7 @@ The current editing has been saved and will be reloaded at next start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+179"/>
+        <location line="+177"/>
         <source>Add</source>
         <translation type="unfinished">Afegeix</translation>
     </message>
@@ -15715,6 +15730,14 @@ Ready.
     <message>
         <location line="+1"/>
         <source>Split each image into 2 fields.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>shaderLoader</name>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-3"/>
+        <source>Reload shader</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/avidemux/qt4/i18n/avidemux_cs.ts
+++ b/avidemux/qt4/i18n/avidemux_cs.ts
@@ -12946,7 +12946,7 @@ Expect problems.</source>
         <translation type="unfinished">Hlavní audio stopa</translation>
     </message>
     <message>
-        <location line="+257"/>
+        <location line="+258"/>
         <source>AvsProxy</source>
         <translation type="unfinished">AvsProxy</translation>
     </message>
@@ -13065,7 +13065,7 @@ Je spuštěno?</translation>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_libva.cpp" line="+135"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_vdpau_utils.cpp" line="+51"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_xvba.cpp" line="+134"/>
-        <location filename="../../common/gui_main.cpp" line="-243"/>
+        <location filename="../../common/gui_main.cpp" line="-244"/>
         <location line="+27"/>
         <location line="+24"/>
         <location line="+8"/>
@@ -14109,7 +14109,7 @@ Install lame plugin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+289"/>
+        <location line="+290"/>
         <source>Oops</source>
         <translation type="unfinished">Ouha</translation>
     </message>
@@ -14540,6 +14540,11 @@ Do you want to continue anyway ?</source>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_dxva2.cpp" line="+0"/>
         <source>Core has been compiled without DXVA2 support, but the application has been compiled with it.
 Installation mismatch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+246"/>
+        <source>Cannot compile shader</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -17208,7 +17213,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+146"/>
         <source>Width :</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17236,7 +17241,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
+        <location line="+118"/>
         <source>Angle (°):</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17262,7 +17267,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>glShader</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+60"/>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-182"/>
         <source>Shader Loader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17272,12 +17277,12 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+164"/>
+        <location line="+192"/>
         <source>ShaderFile to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>ShaderLoader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18074,7 +18079,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>lavcodec</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+530"/>
+        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+518"/>
         <source>_Bitrate:</source>
         <translation type="unfinished">_Datový tok:</translation>
     </message>
@@ -19444,7 +19449,7 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+220"/>
+        <location line="+222"/>
         <source>Recent Files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19454,7 +19459,7 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished">Nedávné projekty</translation>
     </message>
     <message>
-        <location line="+511"/>
+        <location line="+516"/>
         <source>Play/Stop</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19499,13 +19504,23 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Go to marker A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to marker B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Backward one minute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Forward one minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -19678,7 +19693,7 @@ The current editing has been saved and will be reloaded at next start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+179"/>
+        <location line="+177"/>
         <source>Add</source>
         <translation type="unfinished">Přidat</translation>
     </message>
@@ -20497,6 +20512,14 @@ Ready.
     <message>
         <location line="+1"/>
         <source>Split each image into 2 fields.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>shaderLoader</name>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-3"/>
+        <source>Reload shader</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/avidemux/qt4/i18n/avidemux_da.ts
+++ b/avidemux/qt4/i18n/avidemux_da.ts
@@ -778,10 +778,6 @@ Drop timinginformationer?</translation>
         <translation>Afspil</translation>
     </message>
     <message>
-        <source>Stop [SPACE]</source>
-        <translation type="vanished">Stop [MELLEMRUM]</translation>
-    </message>
-    <message>
         <location line="+26"/>
         <source>Go to previous frame [LEFT]</source>
         <translation>Gå til forrige billede [VENSTRE]</translation>
@@ -1998,7 +1994,7 @@ Gå til Lyd-&gt;Hovedspor for at vælge det aktive.</translation>
         <translation>Hovedlydspor</translation>
     </message>
     <message>
-        <location line="+257"/>
+        <location line="+258"/>
         <source>AvsProxy</source>
         <translation>AvsProxy</translation>
     </message>
@@ -2147,7 +2143,7 @@ Kører den?</translation>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_libva.cpp" line="+135"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_vdpau_utils.cpp" line="+51"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_xvba.cpp" line="+134"/>
-        <location filename="../../common/gui_main.cpp" line="-243"/>
+        <location filename="../../common/gui_main.cpp" line="-244"/>
         <location line="+27"/>
         <location line="+24"/>
         <location line="+8"/>
@@ -2685,7 +2681,7 @@ Forvent problemer.</translation>
         <translation>Indstilling af sproget til det givne sporindeks er ikke muligt: ugyldigt sporindeks!</translation>
     </message>
     <message>
-        <location line="+289"/>
+        <location line="+290"/>
         <source>Oops</source>
         <translation>Ups</translation>
     </message>
@@ -3076,6 +3072,11 @@ Vil du fortsætte alligevel?</translation>
         <location line="+35"/>
         <source>Internal error opening 0x%x</source>
         <translation>Intern fejl ved åbning af 0x%x</translation>
+    </message>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+246"/>
+        <source>Cannot compile shader</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5496,7 +5497,7 @@ Jeg vil antage at den har og prøve at fortsætte</translation>
         <translation>Tilpas størrelse ved brug af openGL.</translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+146"/>
         <source>Width :</source>
         <translation>Bredde:</translation>
     </message>
@@ -5524,7 +5525,7 @@ Jeg vil antage at den har og prøve at fortsætte</translation>
         <translation>Rotér billede en lille smule.</translation>
     </message>
     <message>
-        <location line="+120"/>
+        <location line="+118"/>
         <source>Angle (°):</source>
         <translation>Vinkel (°):</translation>
     </message>
@@ -5550,7 +5551,7 @@ Jeg vil antage at den har og prøve at fortsætte</translation>
 <context>
     <name>glShader</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+60"/>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-182"/>
         <source>Shader Loader</source>
         <translation>Shader-indlæser</translation>
     </message>
@@ -5560,12 +5561,12 @@ Jeg vil antage at den har og prøve at fortsætte</translation>
         <translation>Kør et eksternt shaderprogram.</translation>
     </message>
     <message>
-        <location line="+164"/>
+        <location line="+192"/>
         <source>ShaderFile to load</source>
         <translation>Shaderfil som skal indlæses</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>ShaderLoader</source>
         <translation>Shaderindlæser</translation>
     </message>
@@ -6172,7 +6173,7 @@ Jeg vil antage at den har og prøve at fortsætte</translation>
 <context>
     <name>lavcodec</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+530"/>
+        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+518"/>
         <source>_Bitrate:</source>
         <translation>_Bithastighed:</translation>
     </message>
@@ -7199,7 +7200,7 @@ Slet venligst idx2-filen og genåbn.</translation>
         <translation>&lt;b&gt;Ny version tilgængelig&lt;/b&gt;&lt;br&gt; Version %1&lt;br&gt;Udgivet den %2.&lt;br&gt;Du kan downloade den her&lt;br&gt; &lt;a href=&apos;%3&apos;&gt;%3&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;small&gt; Du kan deaktivere automatisk opdatering i præferencer.&lt;/small&gt;</translation>
     </message>
     <message>
-        <location line="+220"/>
+        <location line="+222"/>
         <source>Recent Files</source>
         <translation>Seneste filer</translation>
     </message>
@@ -7209,59 +7210,69 @@ Slet venligst idx2-filen og genåbn.</translation>
         <translation>Seneste projekter</translation>
     </message>
     <message>
-        <location line="+511"/>
+        <location line="+516"/>
         <source>Play/Stop</source>
-        <translation type="unfinished"></translation>
+        <translation>Afspil/stop</translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to previous frame</source>
-        <translation type="unfinished"></translation>
+        <translation>Gå til forrige billede</translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to next frame</source>
-        <translation type="unfinished"></translation>
+        <translation>Gå til næste billede</translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to previous keyframe</source>
-        <translation type="unfinished"></translation>
+        <translation>Gå til forrige nøglebillede</translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to next keyframe</source>
-        <translation type="unfinished"></translation>
+        <translation>Gå til næste nøglebillede</translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Set start marker</source>
-        <translation type="unfinished"></translation>
+        <translation>Sæt startmarkør</translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Set end marker</source>
-        <translation type="unfinished"></translation>
+        <translation>Sæt slutmarkør</translation>
     </message>
     <message>
         <location line="+5"/>
         <source>Go to first frame</source>
-        <translation type="unfinished"></translation>
+        <translation>Gå til første billede</translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to last frame</source>
-        <translation type="unfinished"></translation>
+        <translation>Gå til sidste billede</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Go to marker A</source>
-        <translation type="unfinished"></translation>
+        <translation>Gå til markør A</translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to marker B</source>
-        <translation type="unfinished"></translation>
+        <translation>Gå til markør B</translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Backward one minute</source>
+        <translation>Baglæns ét minut</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Forward one minute</source>
+        <translation>Fremad ét minut</translation>
     </message>
     <message>
         <location line="+491"/>
@@ -7434,7 +7445,7 @@ Den aktuelle redigering er blevet gemt og vil blive genindlæst ved næste start
         <translation>Dette filter kan ikke gøre delvist</translation>
     </message>
     <message>
-        <location line="+179"/>
+        <location line="+177"/>
         <source>Add</source>
         <translation>Tilføj</translation>
     </message>
@@ -8147,7 +8158,7 @@ Klar.
     <message>
         <location filename="../ADM_UIs/src/DIA_flyDialog.cpp" line="+81"/>
         <source>Back one minute</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Baglæns ét minut</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -8157,12 +8168,12 @@ Klar.
     <message>
         <location line="+1"/>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>Afspil</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>Next image</source>
-        <translation type="unfinished"></translation>
+        <translation>Næste billede</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -8177,7 +8188,7 @@ Klar.
     <message>
         <location line="+1"/>
         <source>Forward one minute</source>
-        <translation type="unfinished"></translation>
+        <translation>Fremad ét minut</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -8196,6 +8207,14 @@ Klar.
         <location line="+1"/>
         <source>Split each image into 2 fields.</source>
         <translation>Opdel hvert billede i 2 felter.</translation>
+    </message>
+</context>
+<context>
+    <name>shaderLoader</name>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-3"/>
+        <source>Reload shader</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/avidemux/qt4/i18n/avidemux_de.ts
+++ b/avidemux/qt4/i18n/avidemux_de.ts
@@ -5320,7 +5320,7 @@ Drop timing informations ?</source>
     <message>
         <location line="+3"/>
         <source>Alt+Return</source>
-        <translation type="unfinished">Alt+i</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+9"/>
@@ -5775,7 +5775,7 @@ Drop timing informations ?</source>
     <message>
         <location line="-511"/>
         <source>Frame type:</source>
-        <translation type="unfinished">Bildtyp:</translation>
+        <translation>Frame-Typ:</translation>
     </message>
     <message>
         <location line="+499"/>
@@ -5886,7 +5886,7 @@ Drop timing informations ?</source>
     <message>
         <location line="-736"/>
         <source>Play [SPACE]</source>
-        <translation>Wiedergabe/Pause [Leertaste]</translation>
+        <translation>Wiedergabe/Stopp [Leertaste]</translation>
     </message>
     <message>
         <location line="+29"/>
@@ -7680,7 +7680,7 @@ Drop timing informations ?</source>
     <message>
         <location line="+23"/>
         <source>Play/Stop</source>
-        <translation type="unfinished">Wiedergabe/Pause</translation>
+        <translation>Wiedergabe/Stopp</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -7965,12 +7965,12 @@ Drop timing informations ?</source>
         <location line="+27"/>
         <location line="+35"/>
         <source>Codec Error</source>
-        <translation type="unfinished">Codec Fehler</translation>
+        <translation>Codec-Fehler</translation>
     </message>
     <message>
         <location filename="../../common/gui_main.cpp" line="+337"/>
         <source>Not coded in this version</source>
-        <translation type="unfinished">Nicht in dieser Version eingebaut</translation>
+        <translation>Nicht implementiert in dieser Version</translation>
     </message>
     <message>
         <source>Select AVI File...</source>
@@ -8029,8 +8029,8 @@ Drop timing informations ?</source>
         <location line="+0"/>
         <source>The file you just loaded contains several audio tracks.
 Go to Audio-&gt;MainTrack to select the active one.</source>
-        <translation type="unfinished">Die soeben geladene Datei enthält mehrere Audio-Spuren.
-Gehe zu Audio-&gt;Hauptspur und wähle die aktive Tonspur aus.</translation>
+        <translation>Die soeben geladene Datei enthält mehrere Audio-Spuren.
+Wählen Sie unter &apos;Audio&apos; -&gt; &apos;Tonspur wählen&apos; die aktive Tonspur aus.</translation>
     </message>
     <message>
         <location line="+105"/>
@@ -8091,7 +8091,7 @@ Expect problems.</source>
         <translation type="unfinished">Haupt-Tonspur</translation>
     </message>
     <message>
-        <location line="+257"/>
+        <location line="+258"/>
         <source>AvsProxy</source>
         <translation type="unfinished">Avs-Proxy</translation>
     </message>
@@ -8100,7 +8100,7 @@ Expect problems.</source>
         <source>Failed to connect to avsproxy.
 Is it running ?</source>
         <translation type="unfinished">Fehler beim Verbinden mit dem Avs-Proxy.
-Läuft es trotzdem?</translation>
+Läuft er?</translation>
     </message>
     <message>
         <location line="+5"/>
@@ -8110,7 +8110,7 @@ Läuft es trotzdem?</translation>
     <message>
         <location line="+34"/>
         <source>Frame type:</source>
-        <translation type="unfinished">Bildtyp:</translation>
+        <translation>Frame-Typ:</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -8200,7 +8200,7 @@ Läuft es trotzdem?</translation>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_libva.cpp" line="+135"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_vdpau_utils.cpp" line="+51"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_xvba.cpp" line="+134"/>
-        <location filename="../../common/gui_main.cpp" line="-243"/>
+        <location filename="../../common/gui_main.cpp" line="-244"/>
         <location line="+27"/>
         <location line="+24"/>
         <location line="+8"/>
@@ -8877,7 +8877,7 @@ It is needed to create PSP compatible video.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+500"/>
+        <location line="+501"/>
         <source>Oops</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9489,6 +9489,11 @@ Trotzdem fortsetzen?</translation>
 Installation mismatch</source>
         <translation type="unfinished">Avidemux-Core wurde ohne DXVA2-Unterstützung kompiliert, die Avidemux-Anwendung jedoch mit.
 Nichtübereinstimmende Installation</translation>
+    </message>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+246"/>
+        <source>Cannot compile shader</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10217,13 +10222,13 @@ Trotzdem fortsetzen?</translation>
         <location filename="../../../avidemux_plugins/ADM_videoFilters6/contrast/qt4/Q_contrast.cpp" line="+64"/>
         <location line="+86"/>
         <source>Contrast</source>
-        <translation type="unfinished">Kontrast</translation>
+        <translation>Kontrast</translation>
     </message>
     <message>
         <location filename="../../../avidemux_plugins/ADM_videoFilters6/contrast/qt4/Q_contrast.cpp" line="-85"/>
         <location line="+86"/>
         <source>Brightness</source>
-        <translation type="unfinished"></translation>
+        <translation>Helligkeit</translation>
     </message>
 </context>
 <context>
@@ -10232,19 +10237,7 @@ Trotzdem fortsetzen?</translation>
         <location filename="../../../avidemux_plugins/ADM_videoFilters6/contrast/qt4/contrast.ui" line="+14"/>
         <location line="+19"/>
         <source>Contrast</source>
-        <translation type="unfinished">Kontrast</translation>
-    </message>
-    <message>
-        <source>Contrast:</source>
-        <translation type="obsolete">Kontrast:</translation>
-    </message>
-    <message>
-        <source>Brightness:</source>
-        <translation type="obsolete">Helligkeit:</translation>
-    </message>
-    <message>
-        <source>Colour Space</source>
-        <translation type="obsolete">Farbraum</translation>
+        <translation>Kontrast</translation>
     </message>
     <message>
         <location line="+94"/>
@@ -10259,27 +10252,27 @@ Trotzdem fortsetzen?</translation>
     <message>
         <location line="-48"/>
         <source>Contrast  </source>
-        <translation type="unfinished"></translation>
+        <translation>Kontrast  </translation>
     </message>
     <message>
         <location line="+41"/>
         <source>Brightness  </source>
-        <translation type="unfinished"></translation>
+        <translation>Helligkeit  </translation>
     </message>
     <message>
         <location line="+46"/>
         <source>ChromaU</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Farbkomponente U</translation>
     </message>
     <message>
         <location line="+7"/>
         <source>ChromaV</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Farbkomponente V</translation>
     </message>
     <message>
         <location line="+14"/>
         <source>Process</source>
-        <translation type="unfinished"></translation>
+        <translation>Vorschau</translation>
     </message>
     <message>
         <location line="+22"/>
@@ -12150,7 +12143,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+146"/>
         <source>Width :</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12178,7 +12171,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
+        <location line="+118"/>
         <source>Angle (°):</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12204,7 +12197,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>glShader</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+60"/>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-182"/>
         <source>Shader Loader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12214,12 +12207,12 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+164"/>
+        <location line="+192"/>
         <source>ShaderFile to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>ShaderLoader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13017,7 +13010,7 @@ der Halbbilder (deinterlaceing)</translation>
 <context>
     <name>lavcodec</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+530"/>
+        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+518"/>
         <source>_Bitrate:</source>
         <translation type="unfinished">_Bitrate (kb/s):</translation>
     </message>
@@ -14307,7 +14300,7 @@ Please delete the idx2 file and reopen.</source>
 <context>
     <name>qgui2</name>
     <message>
-        <location filename="../ADM_userInterfaces/ADM_gui/Q_gui2.cpp" line="+443"/>
+        <location filename="../ADM_userInterfaces/ADM_gui/Q_gui2.cpp" line="+445"/>
         <source>Recent Files</source>
         <translation>Zuletzt verwendete &amp;Dateien</translation>
     </message>
@@ -14317,7 +14310,7 @@ Please delete the idx2 file and reopen.</source>
         <translation>Zuletzt verwendete &amp;Projekte</translation>
     </message>
     <message>
-        <location line="+511"/>
+        <location line="+516"/>
         <source>Play/Stop</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14362,7 +14355,7 @@ Please delete the idx2 file and reopen.</source>
         <translation>Zum letzten Frame gehen</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Go to marker A</source>
         <translation>Zur Markierung A gehen</translation>
     </message>
@@ -14372,20 +14365,31 @@ Please delete the idx2 file and reopen.</source>
         <translation>Zur Markierung B gehen</translation>
     </message>
     <message>
+        <location line="+16"/>
+        <source>Backward one minute</source>
+        <translation>Eine Minute zurück</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Forward one minute</source>
+        <translation>Eine Minute vor</translation>
+    </message>
+    <message>
         <location line="+1058"/>
         <source> (%d track(s))</source>
         <translation> (%d Tonspur(en))</translation>
     </message>
     <message>
-        <location line="-1824"/>
+        <location line="-1848"/>
         <source>&lt;b&gt;New version available&lt;/b&gt;&lt;br&gt; Version %1&lt;br&gt;Released on %2.&lt;br&gt;You can download it here&lt;br&gt; &lt;a href=&apos;%3&apos;&gt;%3&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;small&gt; You can disable autoupdate in preferences.&lt;/small&gt;</source>
         <translation>&lt;b&gt;Neue Version verfügbar&lt;/b&gt;&lt;br&gt;Version %1&lt;br&gt;Freigegeben am %2.&lt;br&gt;Das Update kann hier heruntergeladen werden:&lt;br&gt;&lt;a href=&apos;%3&apos;&gt;%3&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;small&gt;Sie können automatische Überprüfung auf Updates in Einstellungen deaktivieren.&lt;/small&gt;</translation>
     </message>
     <message>
-        <location line="+1257"/>
+        <location line="+1281"/>
         <source>The application has encountered a fatal problem
 The current editing has been saved and will be reloaded at next start</source>
-        <translation type="unfinished"></translation>
+        <translation>Die Anwendung hat ein schwerwiegendes Problem festgestellt.
+Der letzte Bearbeitungsstand wurde gespeichert und wird beim nächsten Anwendungsstart geladen.</translation>
     </message>
     <message>
         <location line="+262"/>
@@ -14546,7 +14550,7 @@ The current editing has been saved and will be reloaded at next start</source>
         <translation>Dieser Filter kann nicht abschnittsweise angewendet werden</translation>
     </message>
     <message>
-        <location line="+179"/>
+        <location line="+177"/>
         <source>Add</source>
         <translation>Hinzufügen</translation>
     </message>
@@ -15370,6 +15374,14 @@ Ready.
         <location line="+1"/>
         <source>Split each image into 2 fields.</source>
         <translation type="unfinished">Jedes Bild in zwei Halbbilder aufspalten.</translation>
+    </message>
+</context>
+<context>
+    <name>shaderLoader</name>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-3"/>
+        <source>Reload shader</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -16246,7 +16258,7 @@ Wenn dies eine mitgelieferte Konfiguration ist, wird sie nach Neustart der Anwen
     <message>
         <location line="+270"/>
         <source>Rate Control</source>
-        <translation type="unfinished">Bitraten-Kontrolle     [die entsprechenden x264.exe CLI Schalter sind in &quot;[ ]&quot; angegeben]</translation>
+        <translation type="unfinished">Bitraten-Kontrolle (die entsprechenden x264 CLI Schalter sind in &quot;[ ]&quot; angegeben)</translation>
     </message>
     <message>
         <location line="+8"/>
@@ -17256,17 +17268,17 @@ Möchten Sie fortfahren?</translation>
     <message>
         <location line="-3568"/>
         <source>Basic</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Grundlegend</translation>
     </message>
     <message>
         <location line="+6"/>
         <source>Use advanced configuration</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Erweiterte Konfiguration verwenden</translation>
     </message>
     <message>
         <location line="+9"/>
         <source>Profile:</source>
-        <translation type="unfinished"></translation>
+        <translation>Profil:</translation>
     </message>
     <message>
         <location line="+7"/>
@@ -17781,7 +17793,7 @@ Wenn dies eine mitgelieferte Konfiguration ist, wird sie nach Neustart der Anwen
     <message>
         <location line="+6"/>
         <source>Basic</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Grundlegend</translation>
     </message>
     <message>
         <location line="+6"/>

--- a/avidemux/qt4/i18n/avidemux_el.ts
+++ b/avidemux/qt4/i18n/avidemux_el.ts
@@ -6043,7 +6043,7 @@ Expect problems.</source>
         <translation>Κύριο Κανάλι Ήχου</translation>
     </message>
     <message>
-        <location line="+257"/>
+        <location line="+258"/>
         <source>AvsProxy</source>
         <translation>AvsProxy</translation>
     </message>
@@ -6153,7 +6153,7 @@ Is it running ?</source>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_libva.cpp" line="+135"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_vdpau_utils.cpp" line="+51"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_xvba.cpp" line="+134"/>
-        <location filename="../../common/gui_main.cpp" line="-241"/>
+        <location filename="../../common/gui_main.cpp" line="-242"/>
         <location line="+27"/>
         <location line="+24"/>
         <location line="+8"/>
@@ -6976,7 +6976,7 @@ It is needed to create PSP compatible video.</source>
         <translation>Ο ορισμός της γλώσσας για τα περιεχόμενα του δοσμένου καναλιού δεν είναι εφικτός: Μη έγκυρα περιεχόμενα καναλιού.</translation>
     </message>
     <message>
-        <location line="+179"/>
+        <location line="+180"/>
         <source>Frame Hex Dump</source>
         <translation>Εξαγωνική Απόρριψη Καρέ</translation>
     </message>
@@ -7627,6 +7627,11 @@ Do you want to continue anyway ?</source>
 Installation mismatch</source>
         <translation>Ο πυρήνας έχει συντεθεί χωρίς υποστήριξη του DXVA2, όμως, η εφαρμογή έχει συντεθεί με αυτήν.
 Αταίριαστη η εγκατάσταση.</translation>
+    </message>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+246"/>
+        <source>Cannot compile shader</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10244,7 +10249,7 @@ I will assume it has and try to continue</source>
         <translation>Αλλαγή των διαστάσεων με τη χρήση του openGl.</translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+146"/>
         <source>Width :</source>
         <translation>Πλάτος :</translation>
     </message>
@@ -10272,7 +10277,7 @@ I will assume it has and try to continue</source>
         <translation>Περιστροφή της εικόνας κατά ένα μικρό μέγεθος.</translation>
     </message>
     <message>
-        <location line="+120"/>
+        <location line="+118"/>
         <source>Angle (°):</source>
         <translation>Γωνία (°):</translation>
     </message>
@@ -10298,7 +10303,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>glShader</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+60"/>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-182"/>
         <source>Shader Loader</source>
         <translation>Φορτωτής Σκίασης</translation>
     </message>
@@ -10308,12 +10313,12 @@ I will assume it has and try to continue</source>
         <translation>Τρέξιμο ενός εξωτερικού προγράμματος σκίασης.</translation>
     </message>
     <message>
-        <location line="+164"/>
+        <location line="+192"/>
         <source>ShaderFile to load</source>
         <translation>ΑρχείοΣκίασης προς φόρτωση</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>ShaderLoader</source>
         <translation>ΦορτωτήςΣκίασης</translation>
     </message>
@@ -11062,7 +11067,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>lavcodec</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+530"/>
+        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+518"/>
         <source>_Bitrate:</source>
         <translation>Ρυθμός_Μπιτιών:</translation>
     </message>
@@ -12264,7 +12269,7 @@ Please delete the idx2 file and reopen.</source>
         <translation>&lt;b&gt;Διαθέσιμη νέα έκδοση&lt;/b&gt;&lt;br&gt; Έκδοση %1&lt;br&gt;Εκδόθηκε στις %2.&lt;br&gt;Μπορείς να το κατεβάσεις από εδώ&lt;br&gt; &lt;a href=&apos;%3&apos;&gt;%3&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;small&gt; Μπορείς να απενεργοποιήσεις την αυτόματη ενημέρωση στις προτιμήσεις.&lt;/small&gt;</translation>
     </message>
     <message>
-        <location line="+220"/>
+        <location line="+222"/>
         <source>Recent Files</source>
         <translation>Πρόσφατα Αρχεία</translation>
     </message>
@@ -12274,7 +12279,7 @@ Please delete the idx2 file and reopen.</source>
         <translation>Πρόσφατες Εργασίες</translation>
     </message>
     <message>
-        <location line="+511"/>
+        <location line="+516"/>
         <source>Play/Stop</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12319,13 +12324,23 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Go to marker A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to marker B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Backward one minute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Forward one minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -12499,7 +12514,7 @@ The current editing has been saved and will be reloaded at next start</source>
         <translation>Αυτός ε μεταμορφωτής δεν μπορεί να γίνει μερικός</translation>
     </message>
     <message>
-        <location line="+179"/>
+        <location line="+177"/>
         <source>Add</source>
         <translation>Προσθήκη</translation>
     </message>
@@ -13297,6 +13312,14 @@ Ready.
         <location line="+1"/>
         <source>Split each image into 2 fields.</source>
         <translation>Χωρισμός της κάθε εικόνας σε 2 πεδία.</translation>
+    </message>
+</context>
+<context>
+    <name>shaderLoader</name>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-3"/>
+        <source>Reload shader</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/avidemux/qt4/i18n/avidemux_en.ts
+++ b/avidemux/qt4/i18n/avidemux_en.ts
@@ -2262,7 +2262,7 @@ Expect problems.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+137"/>
+        <location line="+138"/>
         <source>AvsProxy</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3038,6 +3038,11 @@ Do you want to continue anyway ?</source>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_dxva2.cpp" line="+0"/>
         <source>Core has been compiled without DXVA2 support, but the application has been compiled with it.
 Installation mismatch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+246"/>
+        <source>Cannot compile shader</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5400,7 +5405,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+146"/>
         <source>Width :</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5428,7 +5433,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
+        <location line="+118"/>
         <source>Angle (°):</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5454,7 +5459,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>glShader</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+60"/>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-182"/>
         <source>Shader Loader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5464,12 +5469,12 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+164"/>
+        <location line="+192"/>
         <source>ShaderFile to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>ShaderLoader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6076,7 +6081,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>lavcodec</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+530"/>
+        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+518"/>
         <source>_Bitrate:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7101,7 +7106,7 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+220"/>
+        <location line="+222"/>
         <source>Recent Files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7111,7 +7116,7 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+511"/>
+        <location line="+516"/>
         <source>Play/Stop</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7156,13 +7161,23 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Go to marker A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to marker B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Backward one minute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Forward one minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7335,7 +7350,7 @@ The current editing has been saved and will be reloaded at next start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+179"/>
+        <location line="+177"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8093,6 +8108,14 @@ Ready.
     <message>
         <location line="+1"/>
         <source>Split each image into 2 fields.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>shaderLoader</name>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-3"/>
+        <source>Reload shader</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/avidemux/qt4/i18n/avidemux_es.ts
+++ b/avidemux/qt4/i18n/avidemux_es.ts
@@ -6683,7 +6683,7 @@ Expect problems.</source>
         <translation type="unfinished">Pista de sonido principal</translation>
     </message>
     <message>
-        <location line="+257"/>
+        <location line="+258"/>
         <source>AvsProxy</source>
         <translation type="unfinished">AvsProxy</translation>
     </message>
@@ -6828,7 +6828,7 @@ Is it running ?</source>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_libva.cpp" line="+135"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_vdpau_utils.cpp" line="+51"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_xvba.cpp" line="+134"/>
-        <location filename="../../common/gui_main.cpp" line="-243"/>
+        <location filename="../../common/gui_main.cpp" line="-244"/>
         <location line="+27"/>
         <location line="+24"/>
         <location line="+8"/>
@@ -7516,7 +7516,7 @@ Installation mismatch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+289"/>
+        <location line="+290"/>
         <source>Oops</source>
         <translation type="unfinished">¡Vaya!</translation>
     </message>
@@ -7979,6 +7979,11 @@ Do you want to continue anyway ?</source>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_dxva2.cpp" line="+0"/>
         <source>Core has been compiled without DXVA2 support, but the application has been compiled with it.
 Installation mismatch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+246"/>
+        <source>Cannot compile shader</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -10571,7 +10576,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+146"/>
         <source>Width :</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10599,7 +10604,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
+        <location line="+118"/>
         <source>Angle (°):</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10625,7 +10630,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>glShader</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+60"/>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-182"/>
         <source>Shader Loader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10635,12 +10640,12 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+164"/>
+        <location line="+192"/>
         <source>ShaderFile to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>ShaderLoader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11404,7 +11409,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>lavcodec</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+530"/>
+        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+518"/>
         <source>_Bitrate:</source>
         <translation type="unfinished">_Bitrate:</translation>
     </message>
@@ -12644,7 +12649,7 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+220"/>
+        <location line="+222"/>
         <source>Recent Files</source>
         <translation type="unfinished">Archivos Recientes</translation>
     </message>
@@ -12654,7 +12659,7 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished">Proyectos Recientes</translation>
     </message>
     <message>
-        <location line="+511"/>
+        <location line="+516"/>
         <source>Play/Stop</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12699,13 +12704,23 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Go to marker A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to marker B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Backward one minute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Forward one minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -12878,7 +12893,7 @@ The current editing has been saved and will be reloaded at next start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+179"/>
+        <location line="+177"/>
         <source>Add</source>
         <translation type="unfinished">Añadir</translation>
     </message>
@@ -13704,6 +13719,14 @@ Ready.
     <message>
         <location line="+1"/>
         <source>Split each image into 2 fields.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>shaderLoader</name>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-3"/>
+        <source>Reload shader</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/avidemux/qt4/i18n/avidemux_eu.ts
+++ b/avidemux/qt4/i18n/avidemux_eu.ts
@@ -5992,7 +5992,7 @@ Expect problems.</source>
         <translation>Audio Bide Nagusia</translation>
     </message>
     <message>
-        <location line="+257"/>
+        <location line="+258"/>
         <source>AvsProxy</source>
         <translation>AvsProxy</translation>
     </message>
@@ -6116,7 +6116,7 @@ Ekinean dago ?</translation>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_libva.cpp" line="+135"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_vdpau_utils.cpp" line="+51"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_xvba.cpp" line="+134"/>
-        <location filename="../../common/gui_main.cpp" line="-243"/>
+        <location filename="../../common/gui_main.cpp" line="-244"/>
         <location line="+27"/>
         <location line="+24"/>
         <location line="+8"/>
@@ -6693,7 +6693,7 @@ Installation mismatch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+289"/>
+        <location line="+290"/>
         <source>Oops</source>
         <translation type="unfinished">Ustekabea</translation>
     </message>
@@ -7074,6 +7074,11 @@ Do you want to continue anyway ?</source>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_dxva2.cpp" line="+0"/>
         <source>Core has been compiled without DXVA2 support, but the application has been compiled with it.
 Installation mismatch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+246"/>
+        <source>Cannot compile shader</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -9781,7 +9786,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+146"/>
         <source>Width :</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9809,7 +9814,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
+        <location line="+118"/>
         <source>Angle (°):</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9835,7 +9840,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>glShader</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+60"/>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-182"/>
         <source>Shader Loader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9845,12 +9850,12 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+164"/>
+        <location line="+192"/>
         <source>ShaderFile to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>ShaderLoader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10655,7 +10660,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>lavcodec</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+530"/>
+        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+518"/>
         <source>_Bitrate:</source>
         <translation type="unfinished">_Bitneurria:</translation>
     </message>
@@ -11974,7 +11979,7 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+220"/>
+        <location line="+222"/>
         <source>Recent Files</source>
         <translation type="unfinished">Azken Agiriak</translation>
     </message>
@@ -11984,7 +11989,7 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished">Azken Egitasmoak</translation>
     </message>
     <message>
-        <location line="+511"/>
+        <location line="+516"/>
         <source>Play/Stop</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12029,13 +12034,23 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Go to marker A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to marker B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Backward one minute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Forward one minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -12208,7 +12223,7 @@ The current editing has been saved and will be reloaded at next start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+179"/>
+        <location line="+177"/>
         <source>Add</source>
         <translation type="unfinished">Gehitu</translation>
     </message>
@@ -13058,6 +13073,14 @@ Ready.
     <message>
         <location line="+1"/>
         <source>Split each image into 2 fields.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>shaderLoader</name>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-3"/>
+        <source>Reload shader</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/avidemux/qt4/i18n/avidemux_fr.ts
+++ b/avidemux/qt4/i18n/avidemux_fr.ts
@@ -849,10 +849,6 @@ Ignorer les informations de timing ?</translation>
         <translation type="obsolete">Options</translation>
     </message>
     <message>
-        <source>&lt;b&gt;Video Decoder&lt;b&gt;</source>
-        <translation type="vanished">&lt;b&gt;Décodeur Vidéo&lt;/b&gt;</translation>
-    </message>
-    <message>
         <location line="+182"/>
         <location line="+142"/>
         <location line="+169"/>
@@ -1013,7 +1009,7 @@ Ignorer les informations de timing ?</translation>
     <message>
         <location line="+33"/>
         <source>&lt;b&gt;Video Decoder&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;Décodeur Vidéo&lt;/b&gt;</translation>
     </message>
     <message>
         <location line="+75"/>
@@ -1113,7 +1109,7 @@ Ignorer les informations de timing ?</translation>
     <message>
         <location line="+23"/>
         <source>Backward one minute [CTRL+DOWN]</source>
-        <translation>Reculer d&quot;une minute [CTRL+BAS]</translation>
+        <translation>Reculer d&apos;une minute [CTRL+BAS]</translation>
     </message>
     <message>
         <location line="+23"/>
@@ -1455,7 +1451,7 @@ Ignorer les informations de timing ?</translation>
     <message>
         <location line="+1"/>
         <source>_Revert to saved default output settings on video load</source>
-        <translation>&amp;Revenir aux paramètres par défaut enregistrés lors du chargement vidéo</translation>
+        <translation>_Revenir aux paramètres par défaut enregistrés lors du chargement vidéo</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -1784,7 +1780,7 @@ Ignorer les informations de timing ?</translation>
     <message>
         <location line="+1"/>
         <source>Reset Markers</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Réinitialiser les marqueurs</translation>
     </message>
     <message>
         <location line="+5"/>
@@ -2763,7 +2759,7 @@ Expect problems.</source>
         <translation>Impossible de choisir la langue, piste audio invalide</translation>
     </message>
     <message>
-        <location line="+137"/>
+        <location line="+138"/>
         <source>AvsProxy</source>
         <translation></translation>
     </message>
@@ -3542,6 +3538,11 @@ Voulez-vous continuer ?</translation>
 Installation mismatch</source>
         <translation type="unfinished">Core a été compilé sans le support DXVA2, mais l&apos;application a été compilée avec elle.
 Incompatibilité d&apos;installation</translation>
+    </message>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+246"/>
+        <source>Cannot compile shader</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5962,7 +5963,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+146"/>
         <source>Width :</source>
         <translation type="unfinished">Largeur:</translation>
     </message>
@@ -5990,7 +5991,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
+        <location line="+118"/>
         <source>Angle (°):</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6016,7 +6017,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>glShader</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+60"/>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-182"/>
         <source>Shader Loader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6026,12 +6027,12 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+164"/>
+        <location line="+192"/>
         <source>ShaderFile to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>ShaderLoader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6720,7 +6721,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>lavcodec</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+530"/>
+        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+518"/>
         <source>_Bitrate:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7968,7 +7969,7 @@ Veuillez supprimer le fichier idx2 et rouvrir.</translation>
         <translation>&lt;b&gt;Nouvelle version disponible&lt;/b&gt;&lt;br&gt; Version %1&lt;br&gt;Publié le %2.&lt;br&gt;Vous pouvez la télécharger ici&lt;br&gt; &lt;a href=&apos;%3&apos;&gt;%3&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;small&gt; Vous pouvez désactiver autoupdate dans les préférences.&lt;/small&gt;</translation>
     </message>
     <message>
-        <location line="+220"/>
+        <location line="+222"/>
         <source>Recent Files</source>
         <translation>Fichiers Récents</translation>
     </message>
@@ -7978,59 +7979,69 @@ Veuillez supprimer le fichier idx2 et rouvrir.</translation>
         <translation>Projets Récents</translation>
     </message>
     <message>
-        <location line="+511"/>
+        <location line="+516"/>
         <source>Play/Stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to previous frame</source>
-        <translation type="unfinished"></translation>
+        <translation>Image précédente</translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to next frame</source>
-        <translation type="unfinished"></translation>
+        <translation>Image suivante</translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to previous keyframe</source>
-        <translation type="unfinished"></translation>
+        <translation>Image clé précédente</translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to next keyframe</source>
-        <translation type="unfinished"></translation>
+        <translation>Image clé suivante</translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Set start marker</source>
-        <translation type="unfinished"></translation>
+        <translation>Mettre le marqueur A</translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Set end marker</source>
-        <translation type="unfinished"></translation>
+        <translation>Mettre le marqueur B</translation>
     </message>
     <message>
         <location line="+5"/>
         <source>Go to first frame</source>
-        <translation type="unfinished"></translation>
+        <translation>Aller au début</translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to last frame</source>
-        <translation type="unfinished"></translation>
+        <translation>Aller à la fin</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Go to marker A</source>
-        <translation type="unfinished"></translation>
+        <translation>Aller au marqueur A</translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to marker B</source>
-        <translation type="unfinished"></translation>
+        <translation>Aller au marqueur B</translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Backward one minute</source>
+        <translation>Reculer d&apos;une minute</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Forward one minute</source>
+        <translation>Avancer d&apos;une minute</translation>
     </message>
     <message>
         <location line="+491"/>
@@ -8203,7 +8214,7 @@ L&apos;édition en cours a été enregistrée et sera rechargée au prochain dé
         <translation>Ce filtre ne peut pas être partiel</translation>
     </message>
     <message>
-        <location line="+179"/>
+        <location line="+177"/>
         <source>Add</source>
         <translation>Ajouter</translation>
     </message>
@@ -8981,6 +8992,14 @@ Prêt.</translation>
         <location line="+1"/>
         <source>Split each image into 2 fields.</source>
         <translation>Divisez chaque image en 2 champs.</translation>
+    </message>
+</context>
+<context>
+    <name>shaderLoader</name>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-3"/>
+        <source>Reload shader</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/avidemux/qt4/i18n/avidemux_hu.ts
+++ b/avidemux/qt4/i18n/avidemux_hu.ts
@@ -2396,7 +2396,7 @@ Expect problems.</source>
         <translation>Fő hangsáv</translation>
     </message>
     <message>
-        <location line="+257"/>
+        <location line="+258"/>
         <source>AvsProxy</source>
         <translation>AvsProxy</translation>
     </message>
@@ -2545,7 +2545,7 @@ El lett indítva ?</translation>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_libva.cpp" line="+135"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_vdpau_utils.cpp" line="+51"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_xvba.cpp" line="+134"/>
-        <location filename="../../common/gui_main.cpp" line="-243"/>
+        <location filename="../../common/gui_main.cpp" line="-244"/>
         <location line="+27"/>
         <location line="+24"/>
         <location line="+8"/>
@@ -3117,7 +3117,7 @@ Installation mismatch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+289"/>
+        <location line="+290"/>
         <source>Oops</source>
         <translation type="unfinished">Hopp</translation>
     </message>
@@ -3503,6 +3503,11 @@ Do you want to continue anyway ?</source>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_dxva2.cpp" line="+0"/>
         <source>Core has been compiled without DXVA2 support, but the application has been compiled with it.
 Installation mismatch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+246"/>
+        <source>Cannot compile shader</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5992,7 +5997,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+146"/>
         <source>Width :</source>
         <translation type="unfinished">Szélesség:</translation>
     </message>
@@ -6020,7 +6025,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
+        <location line="+118"/>
         <source>Angle (°):</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6046,7 +6051,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>glShader</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+60"/>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-182"/>
         <source>Shader Loader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6056,12 +6061,12 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+164"/>
+        <location line="+192"/>
         <source>ShaderFile to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>ShaderLoader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6668,7 +6673,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>lavcodec</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+530"/>
+        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+518"/>
         <source>_Bitrate:</source>
         <translation type="unfinished">Bitsebesség:</translation>
     </message>
@@ -7808,7 +7813,7 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+220"/>
+        <location line="+222"/>
         <source>Recent Files</source>
         <translation type="unfinished">Legutóbbi fájlok</translation>
     </message>
@@ -7818,7 +7823,7 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished">Legutóbbi projektek</translation>
     </message>
     <message>
-        <location line="+511"/>
+        <location line="+516"/>
         <source>Play/Stop</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7863,13 +7868,23 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Go to marker A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to marker B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Backward one minute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Forward one minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8042,7 +8057,7 @@ The current editing has been saved and will be reloaded at next start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+179"/>
+        <location line="+177"/>
         <source>Add</source>
         <translation type="unfinished">Hozzáadás</translation>
     </message>
@@ -8834,6 +8849,14 @@ Ready.
     <message>
         <location line="+1"/>
         <source>Split each image into 2 fields.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>shaderLoader</name>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-3"/>
+        <source>Reload shader</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/avidemux/qt4/i18n/avidemux_it.ts
+++ b/avidemux/qt4/i18n/avidemux_it.ts
@@ -9286,7 +9286,7 @@ Expect problems.</source>
         <translation>Traccia audio principale</translation>
     </message>
     <message>
-        <location line="+257"/>
+        <location line="+258"/>
         <source>AvsProxy</source>
         <translation>AvsProxy</translation>
     </message>
@@ -9435,7 +9435,7 @@ Is it running ?</source>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_libva.cpp" line="+135"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_vdpau_utils.cpp" line="+51"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_xvba.cpp" line="+134"/>
-        <location filename="../../common/gui_main.cpp" line="-243"/>
+        <location filename="../../common/gui_main.cpp" line="-244"/>
         <location line="+27"/>
         <location line="+24"/>
         <location line="+8"/>
@@ -9792,7 +9792,7 @@ Installation mismatch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+289"/>
+        <location line="+290"/>
         <source>Oops</source>
         <translation type="unfinished">Ops</translation>
     </message>
@@ -10373,6 +10373,11 @@ Do you want to continue anyway ?</source>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_dxva2.cpp" line="+0"/>
         <source>Core has been compiled without DXVA2 support, but the application has been compiled with it.
 Installation mismatch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+246"/>
+        <source>Cannot compile shader</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -13053,7 +13058,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+146"/>
         <source>Width :</source>
         <translation type="unfinished">Larghezza:</translation>
     </message>
@@ -13081,7 +13086,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
+        <location line="+118"/>
         <source>Angle (°):</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13107,7 +13112,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>glShader</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+60"/>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-182"/>
         <source>Shader Loader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13117,12 +13122,12 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+164"/>
+        <location line="+192"/>
         <source>ShaderFile to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>ShaderLoader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13927,7 +13932,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>lavcodec</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+530"/>
+        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+518"/>
         <source>_Bitrate:</source>
         <translation type="unfinished">_Bitrate:</translation>
     </message>
@@ -15317,7 +15322,7 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+220"/>
+        <location line="+222"/>
         <source>Recent Files</source>
         <translation type="unfinished">File recenti</translation>
     </message>
@@ -15327,7 +15332,7 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished">Progetti recenti</translation>
     </message>
     <message>
-        <location line="+511"/>
+        <location line="+516"/>
         <source>Play/Stop</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15372,13 +15377,23 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Go to marker A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to marker B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Backward one minute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Forward one minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -16006,7 +16021,7 @@ DEI TERMINI E DELLE CONDIZIONI&lt;/span&gt;&lt;/b&gt;&lt;/p&gt;
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+179"/>
+        <location line="+177"/>
         <source>Add</source>
         <translation type="unfinished">Aggiungi</translation>
     </message>
@@ -16856,6 +16871,14 @@ Ready.
     <message>
         <location line="+1"/>
         <source>Split each image into 2 fields.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>shaderLoader</name>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-3"/>
+        <source>Reload shader</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/avidemux/qt4/i18n/avidemux_ja.ts
+++ b/avidemux/qt4/i18n/avidemux_ja.ts
@@ -5080,7 +5080,7 @@ Expect problems.</source>
         <translation type="unfinished">主音声トラック</translation>
     </message>
     <message>
-        <location line="+257"/>
+        <location line="+258"/>
         <source>AvsProxy</source>
         <translation type="unfinished">AvsProxy</translation>
     </message>
@@ -5194,7 +5194,7 @@ Is it running ?</source>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_libva.cpp" line="+135"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_vdpau_utils.cpp" line="+51"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_xvba.cpp" line="+134"/>
-        <location filename="../../common/gui_main.cpp" line="-243"/>
+        <location filename="../../common/gui_main.cpp" line="-244"/>
         <location line="+27"/>
         <location line="+24"/>
         <location line="+8"/>
@@ -5997,7 +5997,7 @@ It is needed to create PSP compatible video.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+289"/>
+        <location line="+290"/>
         <source>Oops</source>
         <translation type="unfinished">しまった</translation>
     </message>
@@ -6634,6 +6634,11 @@ Do you want to continue anyway ?</source>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_dxva2.cpp" line="+0"/>
         <source>Core has been compiled without DXVA2 support, but the application has been compiled with it.
 Installation mismatch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+246"/>
+        <source>Cannot compile shader</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -9117,7 +9122,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+146"/>
         <source>Width :</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9145,7 +9150,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
+        <location line="+118"/>
         <source>Angle (°):</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9171,7 +9176,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>glShader</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+60"/>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-182"/>
         <source>Shader Loader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9181,12 +9186,12 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+164"/>
+        <location line="+192"/>
         <source>ShaderFile to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>ShaderLoader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9922,7 +9927,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>lavcodec</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+530"/>
+        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+518"/>
         <source>_Bitrate:</source>
         <translation type="unfinished">ビットレート(_B):</translation>
     </message>
@@ -11082,7 +11087,7 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+220"/>
+        <location line="+222"/>
         <source>Recent Files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11092,7 +11097,7 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+511"/>
+        <location line="+516"/>
         <source>Play/Stop</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11137,13 +11142,23 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Go to marker A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to marker B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Backward one minute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Forward one minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -11317,7 +11332,7 @@ The current editing has been saved and will be reloaded at next start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+179"/>
+        <location line="+177"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12111,6 +12126,14 @@ Ready.
     <message>
         <location line="+1"/>
         <source>Split each image into 2 fields.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>shaderLoader</name>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-3"/>
+        <source>Reload shader</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/avidemux/qt4/i18n/avidemux_pl.ts
+++ b/avidemux/qt4/i18n/avidemux_pl.ts
@@ -6665,7 +6665,7 @@ Expect problems.</source>
         <translation type="unfinished">Główna ścieżka dźwiękowa</translation>
     </message>
     <message>
-        <location line="+257"/>
+        <location line="+258"/>
         <source>AvsProxy</source>
         <translation type="unfinished">AvsProxy</translation>
     </message>
@@ -6784,7 +6784,7 @@ Czy jest on uruchomiony?</translation>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_libva.cpp" line="+135"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_vdpau_utils.cpp" line="+51"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_xvba.cpp" line="+134"/>
-        <location filename="../../common/gui_main.cpp" line="-243"/>
+        <location filename="../../common/gui_main.cpp" line="-244"/>
         <location line="+27"/>
         <location line="+24"/>
         <location line="+8"/>
@@ -7526,7 +7526,7 @@ It is needed to create PSP compatible video.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+289"/>
+        <location line="+290"/>
         <source>Oops</source>
         <translation type="unfinished">Oops</translation>
     </message>
@@ -8157,6 +8157,11 @@ Do you want to continue anyway ?</source>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_dxva2.cpp" line="+0"/>
         <source>Core has been compiled without DXVA2 support, but the application has been compiled with it.
 Installation mismatch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+246"/>
+        <source>Cannot compile shader</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -10721,7 +10726,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+146"/>
         <source>Width :</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10749,7 +10754,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
+        <location line="+118"/>
         <source>Angle (°):</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10775,7 +10780,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>glShader</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+60"/>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-182"/>
         <source>Shader Loader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10785,12 +10790,12 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+164"/>
+        <location line="+192"/>
         <source>ShaderFile to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>ShaderLoader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11551,7 +11556,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>lavcodec</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+530"/>
+        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+518"/>
         <source>_Bitrate:</source>
         <translation type="unfinished">_Przepływność:</translation>
     </message>
@@ -12715,7 +12720,7 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+220"/>
+        <location line="+222"/>
         <source>Recent Files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12725,7 +12730,7 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+511"/>
+        <location line="+516"/>
         <source>Play/Stop</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12770,13 +12775,23 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Go to marker A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to marker B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Backward one minute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Forward one minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -12949,7 +12964,7 @@ The current editing has been saved and will be reloaded at next start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+179"/>
+        <location line="+177"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13748,6 +13763,14 @@ Ready.
     <message>
         <location line="+1"/>
         <source>Split each image into 2 fields.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>shaderLoader</name>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-3"/>
+        <source>Reload shader</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/avidemux/qt4/i18n/avidemux_pt_BR.ts
+++ b/avidemux/qt4/i18n/avidemux_pt_BR.ts
@@ -2333,7 +2333,7 @@ Expect problems.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+137"/>
+        <location line="+138"/>
         <source>AvsProxy</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3109,6 +3109,11 @@ Do you want to continue anyway ?</source>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_dxva2.cpp" line="+0"/>
         <source>Core has been compiled without DXVA2 support, but the application has been compiled with it.
 Installation mismatch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+246"/>
+        <source>Cannot compile shader</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5471,7 +5476,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+146"/>
         <source>Width :</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5499,7 +5504,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
+        <location line="+118"/>
         <source>Angle (°):</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5525,7 +5530,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>glShader</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+60"/>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-182"/>
         <source>Shader Loader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5535,12 +5540,12 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+164"/>
+        <location line="+192"/>
         <source>ShaderFile to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>ShaderLoader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6154,7 +6159,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>lavcodec</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+530"/>
+        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+518"/>
         <source>_Bitrate:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7186,7 +7191,7 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+220"/>
+        <location line="+222"/>
         <source>Recent Files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7196,7 +7201,7 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+511"/>
+        <location line="+516"/>
         <source>Play/Stop</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7241,13 +7246,23 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Go to marker A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to marker B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Backward one minute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Forward one minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7420,7 +7435,7 @@ The current editing has been saved and will be reloaded at next start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+179"/>
+        <location line="+177"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8185,6 +8200,14 @@ Ready.
     <message>
         <location line="+1"/>
         <source>Split each image into 2 fields.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>shaderLoader</name>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-3"/>
+        <source>Reload shader</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/avidemux/qt4/i18n/avidemux_ru.ts
+++ b/avidemux/qt4/i18n/avidemux_ru.ts
@@ -3809,7 +3809,7 @@ Drop timing informations ?</source>
     <message>
         <location line="-1636"/>
         <source>&lt;b&gt;Video Decoder&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;Декодер видео&lt;/b&gt;</translation>
     </message>
     <message>
         <location line="+1125"/>
@@ -3920,10 +3920,6 @@ Drop timing informations ?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Stop [SPACE]</source>
-        <translation type="obsolete">Остановить [SPACE]</translation>
-    </message>
-    <message>
         <location line="-607"/>
         <source>Go to previous frame [LEFT]</source>
         <translation type="unfinished">Предыдущий кадр [LEFT]</translation>
@@ -3946,12 +3942,12 @@ Drop timing informations ?</source>
     <message>
         <location line="+23"/>
         <source>Set start marker [CTRL+PAGEUP]</source>
-        <translation type="unfinished">Установить маркер A [CTRL+PAGEUP]</translation>
+        <translation type="unfinished">Поставить маркер A [CTRL+PAGEUP]</translation>
     </message>
     <message>
         <location line="+23"/>
         <source>Set end marker [CTRL+PAGEDOWN]</source>
-        <translation type="unfinished">Установить маркер B [CTRL+PAGEDOWN]</translation>
+        <translation type="unfinished">Поставить маркер B [CTRL+PAGEDOWN]</translation>
     </message>
     <message>
         <location line="+26"/>
@@ -4573,12 +4569,12 @@ Drop timing informations ?</source>
     <message>
         <location line="+1"/>
         <source>_Enable alternative keyboard shortcuts</source>
-        <translation type="unfinished"></translation>
+        <translation>_Включить альтернативные горячие клавиши</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>Re_verse UP and DOWN arrow keys for navigation</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">_Обратить действие клавиш UP и DOWN при навигации</translation>
     </message>
     <message>
         <location line="+6"/>
@@ -4690,12 +4686,12 @@ Drop timing informations ?</source>
     <message>
         <location line="+2"/>
         <source>_Default to the directory of the last read file for saving</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">_Сохранять видео в папке с последним прочитанным файлом по умолчании</translation>
     </message>
     <message>
         <location line="+5"/>
         <source>XVideo (best)</source>
-        <translation type="unfinished">XVideo (лучше всего)</translation>
+        <translation type="unfinished">XVideo (лучшее)</translation>
     </message>
     <message>
         <location line="+6"/>
@@ -4854,22 +4850,22 @@ Drop timing informations ?</source>
     <message>
         <location line="+3"/>
         <source>Previous Intra Frame</source>
-        <translation type="unfinished">Предыдущая сцена</translation>
+        <translation>Предыдущий ключевой кадр</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>Next Intra Frame</source>
-        <translation type="unfinished">Следующая сцена</translation>
+        <translation>Следующий ключевой кадр</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>Previous Black Frame</source>
-        <translation type="unfinished">Предыдущий черный кадр</translation>
+        <translation>Предыдущий черный кадр</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>Next Black Frame</source>
-        <translation type="unfinished">Следующий черный кадр</translation>
+        <translation>Следующий черный кадр</translation>
     </message>
     <message>
         <location filename="../../common/ADM_commonUI/DIA_audioFilter.cpp" line="-15"/>
@@ -5100,7 +5096,7 @@ Expect problems.</source>
         <translation type="unfinished">Главная звуковая дорожка</translation>
     </message>
     <message>
-        <location line="+257"/>
+        <location line="+258"/>
         <source>Failed to connect to avsproxy.
 Is it running ?</source>
         <translation type="unfinished">Невозможно соединиться с AvsProxy.
@@ -5204,7 +5200,7 @@ Is it running ?</source>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_libva.cpp" line="+135"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_vdpau_utils.cpp" line="+51"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_xvba.cpp" line="+134"/>
-        <location filename="../../common/gui_main.cpp" line="-243"/>
+        <location filename="../../common/gui_main.cpp" line="-244"/>
         <location line="+27"/>
         <location line="+24"/>
         <location line="+8"/>
@@ -5822,7 +5818,7 @@ Is it running ?</source>
     <message>
         <location line="+4"/>
         <source>Reset Markers</source>
-        <translation type="unfinished"></translation>
+        <translation>Сброс маркеров</translation>
     </message>
     <message>
         <location line="+4"/>
@@ -6086,7 +6082,7 @@ It is needed to create PSP compatible video.</source>
         <translation type="unfinished">Установка языка дорожки невозможна: неверный индекс дорожки!</translation>
     </message>
     <message>
-        <location line="+137"/>
+        <location line="+138"/>
         <source>AvsProxy</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6729,6 +6725,11 @@ Do you want to continue anyway ?</source>
 Installation mismatch</source>
         <translation type="unfinished">Ядро было скомпилировано без поддержки DXVA2, а приложение - с его поддержкой.
 Ошибка установки</translation>
+    </message>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+246"/>
+        <source>Cannot compile shader</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -9290,7 +9291,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished">Изменение размера с помощью OpenGL.</translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+146"/>
         <source>Width :</source>
         <translation type="unfinished">Ширина :</translation>
     </message>
@@ -9318,7 +9319,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished">Поворот изображения на небольшой угол.</translation>
     </message>
     <message>
-        <location line="+120"/>
+        <location line="+118"/>
         <source>Angle (°):</source>
         <translation type="unfinished">Угол (°)</translation>
     </message>
@@ -9344,7 +9345,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>glShader</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+60"/>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-182"/>
         <source>Shader Loader</source>
         <translation type="unfinished">Загрузчик шейдеров</translation>
     </message>
@@ -9354,12 +9355,12 @@ I will assume it has and try to continue</source>
         <translation type="unfinished">Запустите внешнюю программу шейдеров.</translation>
     </message>
     <message>
-        <location line="+164"/>
+        <location line="+192"/>
         <source>ShaderFile to load</source>
         <translation type="unfinished">Файл шейдеров для загрузки</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>ShaderLoader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10117,7 +10118,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>lavcodec</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+530"/>
+        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+518"/>
         <source>_Bitrate:</source>
         <translation type="unfinished">Битрейт:</translation>
     </message>
@@ -11323,7 +11324,7 @@ Please delete the idx2 file and reopen.</source>
         <translation>&lt;b&gt;Новая версия&lt;/b&gt;&lt;br&gt;Версия %1&lt;br&gt;Выпущена %2.&lt;br&gt;Доступна для загрузки с адреса&lt;br&gt;&lt;a href=&apos;%3&apos;&gt;%3&lt;/a&gt;&lt;br&gt;&lt;br&gt;&lt;small&gt;Вы можете отключить автоматическую проверку обновлений в настройках.&lt;/small&gt;</translation>
     </message>
     <message>
-        <location line="+220"/>
+        <location line="+222"/>
         <source>Recent Files</source>
         <translation type="unfinished">Предыдущие файлы</translation>
     </message>
@@ -11333,59 +11334,69 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished">Предыдущие проекты</translation>
     </message>
     <message>
-        <location line="+511"/>
+        <location line="+516"/>
         <source>Play/Stop</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Старт/стоп</translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to previous frame</source>
-        <translation type="unfinished"></translation>
+        <translation>Предыдущий кадр</translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to next frame</source>
-        <translation type="unfinished"></translation>
+        <translation>Следующий кадр</translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to previous keyframe</source>
-        <translation type="unfinished"></translation>
+        <translation>Предыдущий ключевой кадр</translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to next keyframe</source>
-        <translation type="unfinished"></translation>
+        <translation>Следующий ключевой кадр</translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Set start marker</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Поставить маркер A</translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Set end marker</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Поставить маркер B</translation>
     </message>
     <message>
         <location line="+5"/>
         <source>Go to first frame</source>
-        <translation type="unfinished"></translation>
+        <translation>Первый кадр</translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to last frame</source>
-        <translation type="unfinished"></translation>
+        <translation>Последний кадр</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Go to marker A</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Перейти к маркеру A</translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to marker B</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Перейти к маркеру B</translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Backward one minute</source>
+        <translation>Назад на 1 минуту</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Forward one minute</source>
+        <translation>Вперед на 1 минуту</translation>
     </message>
     <message>
         <location line="+491"/>
@@ -11558,7 +11569,7 @@ The current editing has been saved and will be reloaded at next start</source>
         <translation type="unfinished">Этот фильтр не может быть применен частично</translation>
     </message>
     <message>
-        <location line="+179"/>
+        <location line="+177"/>
         <source>Add</source>
         <translation type="unfinished">Добавить</translation>
     </message>
@@ -12357,6 +12368,14 @@ Ready.
         <location line="+1"/>
         <source>Split each image into 2 fields.</source>
         <translation type="unfinished">Разделить каждое изображение на 2 поля.</translation>
+    </message>
+</context>
+<context>
+    <name>shaderLoader</name>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-3"/>
+        <source>Reload shader</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/avidemux/qt4/i18n/avidemux_sr.ts
+++ b/avidemux/qt4/i18n/avidemux_sr.ts
@@ -4957,7 +4957,7 @@ Expect problems.</source>
         <translation type="unfinished">Главна звучна стаза</translation>
     </message>
     <message>
-        <location line="+257"/>
+        <location line="+258"/>
         <source>AvsProxy</source>
         <translation type="unfinished">AvsProxy</translation>
     </message>
@@ -5071,7 +5071,7 @@ Is it running ?</source>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_libva.cpp" line="+135"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_vdpau_utils.cpp" line="+51"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_xvba.cpp" line="+134"/>
-        <location filename="../../common/gui_main.cpp" line="-243"/>
+        <location filename="../../common/gui_main.cpp" line="-244"/>
         <location line="+27"/>
         <location line="+24"/>
         <location line="+8"/>
@@ -5871,7 +5871,7 @@ It is needed to create PSP compatible video.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+289"/>
+        <location line="+290"/>
         <source>Oops</source>
         <translation type="unfinished">Упс...</translation>
     </message>
@@ -6507,6 +6507,11 @@ Do you want to continue anyway ?</source>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_dxva2.cpp" line="+0"/>
         <source>Core has been compiled without DXVA2 support, but the application has been compiled with it.
 Installation mismatch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+246"/>
+        <source>Cannot compile shader</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -8979,7 +8984,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+146"/>
         <source>Width :</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9007,7 +9012,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
+        <location line="+118"/>
         <source>Angle (°):</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9033,7 +9038,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>glShader</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+60"/>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-182"/>
         <source>Shader Loader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9043,12 +9048,12 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+164"/>
+        <location line="+192"/>
         <source>ShaderFile to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>ShaderLoader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9782,7 +9787,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>lavcodec</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+530"/>
+        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+518"/>
         <source>_Bitrate:</source>
         <translation type="unfinished">_Битски проток:</translation>
     </message>
@@ -10938,7 +10943,7 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+220"/>
+        <location line="+222"/>
         <source>Recent Files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10948,7 +10953,7 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+511"/>
+        <location line="+516"/>
         <source>Play/Stop</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10993,13 +10998,23 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Go to marker A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to marker B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Backward one minute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Forward one minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -11172,7 +11187,7 @@ The current editing has been saved and will be reloaded at next start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+179"/>
+        <location line="+177"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11964,6 +11979,14 @@ Ready.
     <message>
         <location line="+1"/>
         <source>Split each image into 2 fields.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>shaderLoader</name>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-3"/>
+        <source>Reload shader</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/avidemux/qt4/i18n/avidemux_sr@latin.ts
+++ b/avidemux/qt4/i18n/avidemux_sr@latin.ts
@@ -4957,7 +4957,7 @@ Expect problems.</source>
         <translation type="unfinished">Glavna zvučna staza</translation>
     </message>
     <message>
-        <location line="+257"/>
+        <location line="+258"/>
         <source>AvsProxy</source>
         <translation type="unfinished">AvsProxy</translation>
     </message>
@@ -5071,7 +5071,7 @@ Da li je on pokrenut ?</translation>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_libva.cpp" line="+135"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_vdpau_utils.cpp" line="+51"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_xvba.cpp" line="+134"/>
-        <location filename="../../common/gui_main.cpp" line="-243"/>
+        <location filename="../../common/gui_main.cpp" line="-244"/>
         <location line="+27"/>
         <location line="+24"/>
         <location line="+8"/>
@@ -5871,7 +5871,7 @@ It is needed to create PSP compatible video.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+289"/>
+        <location line="+290"/>
         <source>Oops</source>
         <translation type="unfinished">Ups...</translation>
     </message>
@@ -6507,6 +6507,11 @@ Do you want to continue anyway ?</source>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_dxva2.cpp" line="+0"/>
         <source>Core has been compiled without DXVA2 support, but the application has been compiled with it.
 Installation mismatch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+246"/>
+        <source>Cannot compile shader</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -8979,7 +8984,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+146"/>
         <source>Width :</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9007,7 +9012,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
+        <location line="+118"/>
         <source>Angle (°):</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9033,7 +9038,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>glShader</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+60"/>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-182"/>
         <source>Shader Loader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9043,12 +9048,12 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+164"/>
+        <location line="+192"/>
         <source>ShaderFile to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>ShaderLoader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9782,7 +9787,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>lavcodec</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+530"/>
+        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+518"/>
         <source>_Bitrate:</source>
         <translation type="unfinished">_Bitski protok:</translation>
     </message>
@@ -10938,7 +10943,7 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+220"/>
+        <location line="+222"/>
         <source>Recent Files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10948,7 +10953,7 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+511"/>
+        <location line="+516"/>
         <source>Play/Stop</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10993,13 +10998,23 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Go to marker A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to marker B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Backward one minute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Forward one minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -11172,7 +11187,7 @@ The current editing has been saved and will be reloaded at next start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+179"/>
+        <location line="+177"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11964,6 +11979,14 @@ Ready.
     <message>
         <location line="+1"/>
         <source>Split each image into 2 fields.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>shaderLoader</name>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-3"/>
+        <source>Reload shader</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/avidemux/qt4/i18n/avidemux_tr.ts
+++ b/avidemux/qt4/i18n/avidemux_tr.ts
@@ -5374,7 +5374,7 @@ Expect problems.</source>
             </translation>
     </message>
     <message>
-        <location line="+257"/>
+        <location line="+258"/>
         <source>AvsProxy</source>
         <translation type="unfinished">
             </translation>
@@ -5500,7 +5500,7 @@ Is it running ?</source>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_libva.cpp" line="+135"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_vdpau_utils.cpp" line="+51"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_xvba.cpp" line="+134"/>
-        <location filename="../../common/gui_main.cpp" line="-243"/>
+        <location filename="../../common/gui_main.cpp" line="-244"/>
         <location line="+27"/>
         <location line="+24"/>
         <location line="+8"/>
@@ -6305,7 +6305,7 @@ It is needed to create PSP compatible video.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+289"/>
+        <location line="+290"/>
         <source>Oops</source>
         <translation type="unfinished">Ah</translation>
     </message>
@@ -6948,6 +6948,11 @@ Do you want to continue anyway ?</source>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_dxva2.cpp" line="+0"/>
         <source>Core has been compiled without DXVA2 support, but the application has been compiled with it.
 Installation mismatch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+246"/>
+        <source>Cannot compile shader</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -9456,7 +9461,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+146"/>
         <source>Width :</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9484,7 +9489,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
+        <location line="+118"/>
         <source>Angle (°):</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9510,7 +9515,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>glShader</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+60"/>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-182"/>
         <source>Shader Loader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9520,12 +9525,12 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+164"/>
+        <location line="+192"/>
         <source>ShaderFile to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>ShaderLoader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10272,7 +10277,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>lavcodec</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+530"/>
+        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+518"/>
         <source>_Bitrate:</source>
         <translation type="unfinished">
             </translation>
@@ -11458,7 +11463,7 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+220"/>
+        <location line="+222"/>
         <source>Recent Files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11468,7 +11473,7 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+511"/>
+        <location line="+516"/>
         <source>Play/Stop</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11513,13 +11518,23 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Go to marker A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to marker B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Backward one minute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Forward one minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -11692,7 +11707,7 @@ The current editing has been saved and will be reloaded at next start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+179"/>
+        <location line="+177"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12491,6 +12506,14 @@ Ready.
     <message>
         <location line="+1"/>
         <source>Split each image into 2 fields.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>shaderLoader</name>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-3"/>
+        <source>Reload shader</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/avidemux/qt4/i18n/avidemux_zh_TW.ts
+++ b/avidemux/qt4/i18n/avidemux_zh_TW.ts
@@ -7369,7 +7369,7 @@ Expect problems.</source>
         <translation type="unfinished">主要音軌</translation>
     </message>
     <message>
-        <location line="+257"/>
+        <location line="+258"/>
         <source>AvsProxy</source>
         <translation type="unfinished">AvsProxy</translation>
     </message>
@@ -7483,7 +7483,7 @@ Is it running ?</source>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_libva.cpp" line="+135"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_vdpau_utils.cpp" line="+51"/>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_xvba.cpp" line="+134"/>
-        <location filename="../../common/gui_main.cpp" line="-243"/>
+        <location filename="../../common/gui_main.cpp" line="-244"/>
         <location line="+27"/>
         <location line="+24"/>
         <location line="+8"/>
@@ -8269,7 +8269,7 @@ It is needed to create PSP compatible video.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+289"/>
+        <location line="+290"/>
         <source>Oops</source>
         <translation type="unfinished">Oops</translation>
     </message>
@@ -8875,6 +8875,11 @@ Do you want to continue anyway ?</source>
         <location filename="../../common/ADM_videoCodec/src/ADM_ffmpeg_dxva2.cpp" line="+0"/>
         <source>Core has been compiled without DXVA2 support, but the application has been compiled with it.
 Installation mismatch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+246"/>
+        <source>Cannot compile shader</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -11505,7 +11510,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+150"/>
+        <location line="+146"/>
         <source>Width :</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11533,7 +11538,7 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
+        <location line="+118"/>
         <source>Angle (°):</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11559,7 +11564,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>glShader</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="+60"/>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-182"/>
         <source>Shader Loader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11569,12 +11574,12 @@ I will assume it has and try to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+164"/>
+        <location line="+192"/>
         <source>ShaderFile to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>ShaderLoader</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12367,7 +12372,7 @@ I will assume it has and try to continue</source>
 <context>
     <name>lavcodec</name>
     <message>
-        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+530"/>
+        <location filename="../../../avidemux_plugins/ADM_audioEncoders/lavcodec/audioencoder_lavcodec.cpp" line="+518"/>
         <source>_Bitrate:</source>
         <translation type="unfinished">位元率(_B):</translation>
     </message>
@@ -13631,7 +13636,7 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+220"/>
+        <location line="+222"/>
         <source>Recent Files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13641,7 +13646,7 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+511"/>
+        <location line="+516"/>
         <source>Play/Stop</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13686,13 +13691,23 @@ Please delete the idx2 file and reopen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+3"/>
         <source>Go to marker A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Go to marker B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Backward one minute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Forward one minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -13865,7 +13880,7 @@ The current editing has been saved and will be reloaded at next start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+179"/>
+        <location line="+177"/>
         <source>Add</source>
         <translation type="unfinished">加入</translation>
     </message>
@@ -14688,6 +14703,14 @@ Ready.
     <message>
         <location line="+1"/>
         <source>Split each image into 2 fields.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>shaderLoader</name>
+    <message>
+        <location filename="../../../avidemux_plugins/ADM_videoFilters6_openGl/glShaderLoader/shader.cpp" line="-3"/>
+        <source>Reload shader</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
The few fixes for i18n/fr primarily restore the translation of the navigation buttons' tooltips and the "Video Decoder" label. The patch provides also German and Russian translations for recently added preferences concerning keyboard shortcuts and fixes a couple of other bits in the German translation.