### PR TITLE
[build] Fix deb creation on Ubuntu 16.10, add alsa and xvid to deps in the simple build script

### DIFF
--- a/avidemux/qt4/qt4PackageDebian.cmake
+++ b/avidemux/qt4/qt4PackageDebian.cmake
@@ -5,7 +5,7 @@ set(CPACK_COMPONENTS_ALL             runtime dev )
 
 SET(CPACK_DEBIAN_PACKAGE_NAME        "avidemux3-${QT_EXTENSION}")
 SET(CPACK_DEBIAN_PACKAGE_DESCRIPTION "Simple video editor,main program qt4 version ")
-SET(DEPS "libc6 (>=2.4),libstdc++6 (>=4.2.1),libx11-6,  libxv1, zlib1g (>=1:1.1.4), libglib2.0-0, libpng12-0, avidemux3-core-runtime (>=${AVIDEMUX_VERSION})")
+SET(DEPS "libc6 (>=2.4), libstdc++6 (>=4.2.1), libx11-6, zlib1g (>=1:1.1.4), libglib2.0-0, libpng12-0 | libpng16-16, avidemux3-core-runtime (>=${AVIDEMUX_VERSION})")
 # QT5
 SET(DEPS "${DEPS}, libqt5opengl5, libqt5widgets5, libqt5gui5, libqt5core5a")
 IF(USE_XV)

--- a/avidemux_core/corePackageDebian.cmake
+++ b/avidemux_core/corePackageDebian.cmake
@@ -5,7 +5,7 @@ set(CPACK_COMPONENTS_ALL             runtime dev )
 
 SET(CPACK_DEBIAN_PACKAGE_NAME        "avidemux3-core")
 SET(CPACK_DEBIAN_PACKAGE_DESCRIPTION "Simple video editor,core libraries")
-SET(DEPS "libc6 (>=2.4),libstdc++6 (>=4.2.1),libx11-6,  libxv1, zlib1g (>=1:1.1.4), pkg-config, libpng12-0, libsqlite3-0 (>=3.8.0) ")
+SET(DEPS "libc6 (>=2.4), libstdc++6 (>=4.2.1), libx11-6, libxv1, zlib1g (>=1:1.1.4), pkg-config, libpng12-0 | libpng16-16, libsqlite3-0 (>=3.8.0)")
 # Add optional DEPS here
 SET(CPACK_DEBIAN_PACKAGE_DEPENDS "${DEPS}")
 #

--- a/createDebFromSourceUbuntu.bash
+++ b/createDebFromSourceUbuntu.bash
@@ -21,9 +21,9 @@ install_deps()
     echo "You will be asked to enter your password because installing build dependencies requires root permissions"
     # gcc, g++ and make get installed as dependencies of build-essential
     sudo apt-get update && sudo apt-get install build-essential cmake pkg-config yasm \
-    libsqlite3-dev libfontconfig1-dev libfribidi-dev libxv-dev libvdpau-dev libva-dev libpulse-dev \
+    libsqlite3-dev libfontconfig1-dev libfribidi-dev libxv-dev libvdpau-dev libva-dev libasound2-dev libpulse-dev \
     qttools5-dev-tools qtbase5-dev libqt5opengl5-dev \
-    libpng12-dev libaften-dev libmp3lame-dev libx264-dev libfaad-dev libfaac-dev libopus-dev libvorbis-dev libogg-dev libdca-dev \
+    libpng-dev libaften-dev libmp3lame-dev libx264-dev libxvidcore-dev libfaad-dev libfaac-dev libopus-dev libvorbis-dev libogg-dev libdca-dev \
     || { echo "The installation at least of some of the build dependencies failed. Aborting." && exit 2; }
     sudo apt-get install libx265-dev \
     || echo "Warning: libx265-dev cannot be installed using package management. Avidemux won't be able to encode in h265 unless the library and the headers have been installed manually. Continuing anyway." # there are no official libx265 packages for Ubuntu Trusty


### PR DESCRIPTION
`libpng12-0`, declared as build and runtime dependency, is not available anymore on Ubuntu 16.10 and the upcoming 17.04. This patch fixes the `createDebFromSourceUbuntu.bash` script and the installation of the created debs.

Please note that all OpenGL filters broken on Fedora 24 and later are equally broken on Ubuntu 16.10.