### PR TITLE
[plugins/vpx] Fix swapped UV, menu name

### DIFF
--- a/avidemux_plugins/ADM_videoDecoder/vpx/ADM_vpx.cpp
+++ b/avidemux_plugins/ADM_videoDecoder/vpx/ADM_vpx.cpp
@@ -93,11 +93,11 @@ bool    decoderVPX::uncompress (ADMCompressedImage * in, ADMImage * out)
             if(r)
             {
                     r->_planes[0]=img->planes[0];
-                    r->_planes[1]=img->planes[1];
-                    r->_planes[2]=img->planes[2];
+                    r->_planes[1]=img->planes[2];
+                    r->_planes[2]=img->planes[1];
                     r->_planeStride[0]=img->stride[0];
-                    r->_planeStride[1]=img->stride[1];
-                    r->_planeStride[2]=img->stride[2];
+                    r->_planeStride[1]=img->stride[2];
+                    r->_planeStride[2]=img->stride[1];
                     r->_colorspace=ADM_COLOR_YV12;
                     r->Pts=in->demuxerPts;
                     r->flags=in->flags;

--- a/avidemux_plugins/ADM_videoDecoder/vpx/vpxPlugin.cpp
+++ b/avidemux_plugins/ADM_videoDecoder/vpx/vpxPlugin.cpp
@@ -17,7 +17,7 @@
 static uint32_t fccs[]={MKFCC('V','P','8',' '),0};
 ADM_DECLARE_VIDEO_DECODER_PREAMBLE(decoderVPX);
 ADM_DECLARE_VIDEO_DECODER_MAIN("vpx",
-                               "VP8/WebmM",
+                               "VP8/WebM",
                                "Decoder using libvpx (c) mean 2010",
                                 fccs, // No configuration
                                 NULL,


### PR DESCRIPTION
This patch fixes swapped UV when decoding VP8 videos using the vpx plugin along with a cosmetical change correcting the decoder name in the menu.

Alternatively, the build of the vpx decoder in the plugins could be disabled as the internal ffmpeg decodes VP8 videos just fine.

Unsure if this is a trivial change, thus going the way of a pull request.