### PR TITLE
[plugins/vpx] Add VP9 decoding support

### DIFF
--- a/avidemux_plugins/ADM_videoDecoder/vpx/ADM_vpx.cpp
+++ b/avidemux_plugins/ADM_videoDecoder/vpx/ADM_vpx.cpp
@@ -37,8 +37,20 @@ decoderVPX::decoderVPX (uint32_t w, uint32_t h,uint32_t fcc, uint32_t extraDataL
     vpx_codec_dec_cfg_t cfg;
     vpx_codec_flags_t flags=0; //VPX_CODEC_USE_POSTPROC
     vpx_codec_ctx_t *instance=new vpx_codec_ctx_t;
-    const struct vpx_codec_iface *iface = &vpx_codec_vp8_dx_algo;
-    
+    const struct vpx_codec_iface *iface;
+    if(fcc==MKFCC('V','P','8',' '))
+    {
+        iface = &vpx_codec_vp8_dx_algo;
+    }else if(fcc==MKFCC('V','P','9',' '))
+    {
+        iface = &vpx_codec_vp9_dx_algo;
+    }else
+    {
+        ADM_warning("Unsupported FCC\n");
+        delete instance;
+        return;
+    }
+
     memset(instance,0,sizeof(*instance));
     memset(&cfg,0,sizeof(cfg));
     cfg.threads=1;

--- a/avidemux_plugins/ADM_videoDecoder/vpx/vpxPlugin.cpp
+++ b/avidemux_plugins/ADM_videoDecoder/vpx/vpxPlugin.cpp
@@ -14,10 +14,10 @@
 #include "ADM_default.h"
 #include "ADM_coreVideoDecoderInternal.h"
 #include "ADM_vpx.h"
-static uint32_t fccs[]={MKFCC('V','P','8',' '),0};
+static uint32_t fccs[]={MKFCC('V','P','8',' '),MKFCC('V','P','9',' '),0};
 ADM_DECLARE_VIDEO_DECODER_PREAMBLE(decoderVPX);
 ADM_DECLARE_VIDEO_DECODER_MAIN("vpx",
-                               "VP8/WebM",
+                               "VP8/VP9/WebM",
                                "Decoder using libvpx (c) mean 2010",
                                 fccs, // No configuration
                                 NULL,


### PR DESCRIPTION
While I still have no idea why VP9 decoding via the internal FFmpeg fails, it works nicely via the vpx plugin with minimal changes in the code. This patch adds VP9 decoding support, the plugin claims the VP9 FCC now.