### PR TITLE
[muxer] Populate codecpar, silence lavc deprecated warning

### DIFF
--- a/avidemux_plugins/ADM_muxers/muxerFlv/muxerFlv.cpp
+++ b/avidemux_plugins/ADM_muxers/muxerFlv/muxerFlv.cpp
@@ -101,6 +101,7 @@ bool muxerFlv::open(const char *file, ADM_videoStream *s,uint32_t nbAudioTrack,A
     }
 
     AVCodecContext *c = video_st->codec;
+    AVCodecParameters *par = video_st->codecpar;
     AVDictionary *dict = NULL;
 
     rescaleFps(s->getAvgFps1000(),&(c->time_base));

--- a/avidemux_plugins/ADM_muxers/muxerMkv/muxerMkv.cpp
+++ b/avidemux_plugins/ADM_muxers/muxerMkv/muxerMkv.cpp
@@ -75,6 +75,8 @@ bool muxerMkv::open(const char *file, ADM_videoStream *s,uint32_t nbAudioTrack,A
     
         AVCodecContext *c;
         c = video_st->codec;
+        AVCodecParameters *par;
+        par = video_st->codecpar;
         rescaleFps(s->getAvgFps1000(),&(c->time_base));
         video_st->time_base=c->time_base;
         c->gop_size=15;
@@ -84,8 +86,8 @@ bool muxerMkv::open(const char *file, ADM_videoStream *s,uint32_t nbAudioTrack,A
             //sar=display/code  
             int num=1,den=1;
             av_reduce(&num, &den, mkvMuxerConfig.displayWidth, s->getWidth(),65535);
-            c->sample_aspect_ratio.num=num;
-            c->sample_aspect_ratio.den=den;
+            par->sample_aspect_ratio.num=num;
+            par->sample_aspect_ratio.den=den;
             video_st->sample_aspect_ratio.num=num;
             video_st->sample_aspect_ratio.den=den;
             ADM_info("Forcing display width of %d\n",(int)mkvMuxerConfig.displayWidth);

--- a/avidemux_plugins/ADM_muxers/muxerMp4/muxerMP4.cpp
+++ b/avidemux_plugins/ADM_muxers/muxerMp4/muxerMP4.cpp
@@ -93,6 +93,8 @@ bool muxerMP4::open(const char *file, ADM_videoStream *s,uint32_t nbAudioTrack,A
         AVCodecContext *c;
         AVRational myTimeBase;
         c = video_st->codec;
+        AVCodecParameters *par;
+        par = video_st->codecpar;
         rescaleFps(s->getAvgFps1000(),&(c->time_base));
         myTimeBase=video_st->time_base=c->time_base;
         ADM_info("Video stream time base :%d,%d\n",video_st->time_base.num,video_st->time_base.den);

--- a/avidemux_plugins/ADM_muxers/muxerWebm/muxerWebm.cpp
+++ b/avidemux_plugins/ADM_muxers/muxerWebm/muxerWebm.cpp
@@ -95,6 +95,8 @@ bool muxerWebm::open(const char *file, ADM_videoStream *s,uint32_t nbAudioTrack,
     
         AVCodecContext *c;
         c = video_st->codec;
+        AVCodecParameters *par;
+        par = video_st->codecpar;
         rescaleFps(s->getAvgFps1000(),&(c->time_base));
         video_st->time_base=c->time_base;
         c->gop_size=15;
@@ -104,8 +106,8 @@ bool muxerWebm::open(const char *file, ADM_videoStream *s,uint32_t nbAudioTrack,
             //sar=display/code  
             int num=1,den=1;
             av_reduce(&num, &den, WebmMuxerConfig.displayWidth, s->getWidth(),65535);
-            c->sample_aspect_ratio.num=num;
-            c->sample_aspect_ratio.den=den;
+            par->sample_aspect_ratio.num=num;
+            par->sample_aspect_ratio.den=den;
             video_st->sample_aspect_ratio.num=num;
             video_st->sample_aspect_ratio.den=den;
             ADM_info("Forcing display width of %d\n",(int)WebmMuxerConfig.displayWidth);

--- a/avidemux_plugins/ADM_muxers/muxerffPS/muxerffPS.cpp
+++ b/avidemux_plugins/ADM_muxers/muxerffPS/muxerffPS.cpp
@@ -88,11 +88,13 @@ const char *er;
     
         AVCodecContext *c;
         c = video_st->codec;
+        AVCodecParameters *par;
+        par = video_st->codecpar;
 
         // Override codec settings
         rescaleFps(s->getAvgFps1000(),&(c->time_base));
         video_st->time_base=c->time_base;
-        c->bit_rate=psMuxerConfig.videoRatekBits*1000;
+        par->bit_rate=psMuxerConfig.videoRatekBits*1000;
         c->rc_buffer_size=psMuxerConfig.bufferSizekBytes*8*1024;
         c->rc_buffer_size_header=psMuxerConfig.bufferSizekBytes*8*1024;
         c->gop_size=15;
@@ -105,7 +107,7 @@ const char *er;
         }
         for(int i=0;i<nbAudioTrack;i++)
         {
-            audio_st[i]->codec->bit_rate=a[i]->getInfo()->byterate*8;        
+            audio_st[i]->codecpar->bit_rate=a[i]->getInfo()->byterate*8;
         }
 
         int erx = avio_open(&(oc->pb), file, AVIO_FLAG_WRITE);

--- a/avidemux_plugins/ADM_muxers/muxerffTS/muxerffTS.cpp
+++ b/avidemux_plugins/ADM_muxers/muxerffTS/muxerffTS.cpp
@@ -88,6 +88,8 @@ bool muxerffTS::open(const char *file, ADM_videoStream *s,uint32_t nbAudioTrack,
     
         AVCodecContext *c;
         c = video_st->codec;
+        AVCodecParameters *par;
+        par = video_st->codecpar;
         rescaleFps(s->getAvgFps1000(),&(c->time_base));
         video_st->time_base=c->time_base;
         
@@ -100,7 +102,7 @@ bool muxerffTS::open(const char *file, ADM_videoStream *s,uint32_t nbAudioTrack,
         }
         
 		for(int i=0;i<nbAudioTrack;i++)
-            audio_st[i]->codec->bit_rate=a[i]->getInfo()->byterate*8;        
+            audio_st[i]->codecpar->bit_rate=a[i]->getInfo()->byterate*8;
        
         int erx = avio_open(&(oc->pb), file, AVIO_FLAG_WRITE);
 


### PR DESCRIPTION
This patch is probably total rubbish, as I don't understand the matter well enough. Of course, it silences the warning [seen by Jan](http://avidemux.org/smif/index.php/topic,17642.0.html); encoding with FFmpeg-based and other encoders as well as saving in copy mode still seems to work fine. Nevertheless, could you have a look, please?