### PR TITLE
[Qt/mainfilter] Disable horizontal scrolling to work around rendering issues

### DIFF
--- a/avidemux/qt4/ADM_userInterfaces/ADM_filters/Q_mainfilter.h
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_filters/Q_mainfilter.h
@@ -105,5 +105,6 @@ private:
     void displayFamily(uint32_t family);
     void setupFilters(void);
     void updateContextMenu(QMenu *contextMenu);
+    int  calculateListItemHeight(void);
 };
 

--- a/avidemux/qt4/ADM_userInterfaces/ADM_filters/mainfilter.ui
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_filters/mainfilter.ui
@@ -48,9 +48,6 @@
          <height>0</height>
         </size>
        </property>
-       <property name="spacing">
-        <number>2</number>
-       </property>
       </widget>
      </item>
      <item row="1" column="4">
@@ -95,9 +92,6 @@
          <width>340</width>
          <height>0</height>
         </size>
-       </property>
-       <property name="spacing">
-        <number>2</number>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
This one could be controversial because tooltips become the only way to access long filter descriptions which get cut off.

Enabling word wrap for labels doesn't work well for me because list items must be 4 lines high to accomodate some translations inc. the German one while `QFontMetrics::elidedText` fails to take `<small>` tags into account.

The following screenshots show the rendering issue.
![video-filter-manager-redraw-issue](https://cloud.githubusercontent.com/assets/23018873/25109647/7d888cf0-23de-11e7-89b4-68833f291d0b.png)

![video-filter-manager-available-selection-extends-into-active](https://cloud.githubusercontent.com/assets/23018873/25109611/37ee18fe-23de-11e7-9afe-8d601312c59f.png)
