### PR TITLE
Allow to specify which port to use for the connection of vapoursynth proxy

### DIFF
--- a/avidemux_plugins/ADM_demuxers/VapourSynth/qt4/vs.ui
+++ b/avidemux_plugins/ADM_demuxers/VapourSynth/qt4/vs.ui
@@ -30,6 +30,30 @@
      </layout>
     </item>
     <item>
+     <layout class="QHBoxLayout" name="horizontalLayout_3">
+      <item>
+       <widget class="QLabel" name="labelPort">
+        <property name="text">
+         <string>Port to use: </string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QSpinBox" name="spinboxPort">
+        <property name="minimum">
+         <number>1024</number>
+        </property>
+        <property name="maximum">
+         <number>65535</number>
+        </property>
+        <property name="value">
+         <number>9999</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item>
      <layout class="QHBoxLayout" name="horizontalLayout_2">
       <item>
        <widget class="QLabel" name="labelStatus">

--- a/avidemux_plugins/ADM_demuxers/VapourSynth/qt4/vsProxy_qt4.cpp
+++ b/avidemux_plugins/ADM_demuxers/VapourSynth/qt4/vsProxy_qt4.cpp
@@ -92,7 +92,7 @@ void                vsWindow::runOrStop()
      std::string fileName=std::string(ui.lineFile->text().toUtf8().constData());
      vapourSynthProxy vs;
                       
-     vs.run(9999,fileName.c_str());
+     vs.run(ui.spinboxPort->value(),fileName.c_str());
      ui.labelStatus->setText(QString("Exited (error ?)"));
 }
 


### PR DESCRIPTION
Working in the same way, as the modification done for avisynth proxy