### PR TITLE
Corrected off by one argument extraction

### DIFF
--- a/avidemux_plugins/ADM_demuxers/VapourSynth/ADM_vsProxy_cli.cpp
+++ b/avidemux_plugins/ADM_demuxers/VapourSynth/ADM_vsProxy_cli.cpp
@@ -60,7 +60,7 @@ int main(int ac, char **av)
             try
             {
                 size_t resPos;
-                std::string strPort(av[avPos + 1]);
+                std::string strPort(av[avPos]);
                 port = std::stoi(strPort, &resPos, 0);
                 if (resPos != strPort.size())
                 {


### PR DESCRIPTION
Incremented the port number port twice by accident, so tried to read out the port value from the wrong position