### PR TITLE
ADM_coreSocket: prevent uninitialized use of *port in createBindAndAc…

### DIFF
--- a/avidemux_core/ADM_coreSocket/src/ADM_coreSocket.cpp
+++ b/avidemux_core/ADM_coreSocket/src/ADM_coreSocket.cpp
@@ -183,8 +183,8 @@ int enable = 1;
 if (setsockopt(mySocket, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int)) < 0)
     ADM_error("Oops : setsockopt(SO_REUSEADDR) failed\n");
 #endif
-
-  ADM_info("Binding on %s:%d\n",BIND_ADR,*port);
+  *port = 0; // Always any port, not only by chance!
+  ADM_info("Binding on %s:%u\n",BIND_ADR,(unsigned int)*port);
   sockaddr_in service;
   service.sin_family = AF_INET;
   service.sin_addr.s_addr = inet_addr(BIND_ADR);


### PR DESCRIPTION
…cept

I noticed random failure (rather, random success) in startup of avidemux3_jobs_qt5,
which seems to relate to a random component in the port used for opening the
background connecton:

Directory /home/user/.avidemux6/ exists.Good.
Using /home/user/.avidemux6/ as base directory for prefs, jobs, etc.
 [jobInit] 18:54:38-080  Initializing database (/home/user/.avidemux6/jobs.sql)
 [ADM_jobCheckVersion] 18:54:38-081  Db version 3, our version 3
 [ADM_jobCheckVersion] 18:54:38-081  Same version, continuing..
 [jobInit] 18:54:38-081  Successfully connected to jobs database..
QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/tmp/runtime-user'
 [createBindAndAccept] 18:54:38-231  Binding on 127.0.0.1:2
 [createBindAndAccept] 18:54:38-231  bind() failed  
 [close] 18:54:38-231  [ADMSocket]Error when socket shutdown  -1 (socket 9)
 [popup] 18:54:38-231  Cannot bind socket
Cleaning up
 [jobShutDown] 18:54:38-234  Shutting down jobs database
 [onexit] 18:54:38-234  
Goodbye...

user@machine:~$ avidemux3_jobs_qt5 
*************************
  Avidemux v2.7.0
*************************
 http://www.avidemux.org
 Code      : Mean, JSC, Gruntster 
 GFX       : Nestor Di , nestordi@augcyl.org
 Design    : Jakub Misak
 FreeBSD   : Anish Mistry, amistry@am-productions.biz
 Audio     : Mihail Zenkov
 MacOsX    : Kuisathaverat
 Win32     : Gruntster

Compiler: GCC 7.2.0
Build Target: Linux (x86-64)

Large file available: 1 offset
Directory /home/user/.avidemux6/ exists.Good.
Using /home/user/.avidemux6/ as base directory for prefs, jobs, etc.
 [jobInit] 18:58:40-054  Initializing database (/home/user/.avidemux6/jobs.sql)
 [ADM_jobCheckVersion] 18:58:40-055  Db version 3, our version 3
 [ADM_jobCheckVersion] 18:58:40-055  Same version, continuing..
 [jobInit] 18:58:40-055  Successfully connected to jobs database..
QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/tmp/runtime-user'
 [createBindAndAccept] 18:58:40-235  Binding on 127.0.0.1:-1006610672
 [createBindAndAccept] 18:58:40-235  Socket bound to port 22288
 [jobWindow] 18:58:40-235  Socket bound to 22288
*
*
*
*
*
 [refreshList] 18:58:40-236  Found 5 jobs

The comments in the ADM_socket::createBindAndAccept() routine suggest
that the value for the port should be 0 when calling bind(). This change
ensures that.

Note: I tested this change on the 2.7.0 release and then went over to
github to hand-edit the trivial change in. I am not fully sure about the
intent of using the provided value of *port at all (even in the log message
before binding). Is it ever initialized? Anyhow, knowledgeable people
should figure out the correct thing to do quickly. I don't mind if you discard
this dirty pull request as long as the proper fix goes in;-)

[And: Is this github repo the official development platform for Avidemux now? I only found it mentioned as ‘mirror’ in the forum … next to the long-dead berios links …]