### PR TITLE
avsfilter bugfix

### DIFF
--- a/addons/avsfilter/winetmppath.cpp
+++ b/addons/avsfilter/winetmppath.cpp
@@ -23,7 +23,7 @@
 extern "C" void wine_tmp_path (AVS_PIPES *avsp, int num)
 {
   WCHAR path[MAX_PATH];
-  GetTempPathW(sizeof(path), path);
+  GetTempPathW(sizeof(path)/sizeof(path[0]), path);
   LPSTR (*wine_get_unix_file_name_ptr)(LPCWSTR) = NULL;
   wine_get_unix_file_name_ptr = (char *(__cdecl *)(const unsigned short *))
       GetProcAddress(GetModuleHandle("KERNEL32"),


### PR DESCRIPTION
avsfilter does not work after wine git commit:
f16cf541068831074a6891688d947f0ce32abdd9 (kernel32: GetTempPathW must zero the remaining buffer.)
GetTempPathW receives size in bytes from wine_tmp_path, but it expects size in wchars.
GetTempPathW (wine source dlls/kernel32/path.c) crashes in line:
memset(path + ret, 0, (count - ret) * sizeof(WCHAR));
because of wrong count value.