### PR TITLE
Sturtup > Load > Window->Maximize [bug?]

### DIFF
--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
@@ -506,7 +506,7 @@ MainWindow::MainWindow(const vector<IScriptEngine*>& scriptEngines) : _scriptEng
 
     threshold = RESIZE_THRESHOLD;
     actZoomCalled = false;
-    ignoreResizeEvent = true;
+    ignoreResizeEvent = false;
     blockResizing = false;
     blockZoomChanges = true;
 


### PR DESCRIPTION
Scenario:
AppStart > Load Video [WindowState=Normal]
Maximize Button Click: video stays in original size [!!]
Now Restore > Maximize again and it works from now.

Im not familiar with code, but changing this line can fix this?