### PR TITLE
Update avidemux2.desktop

### DIFF
--- a/avidemux2.desktop
+++ b/avidemux2.desktop
@@ -1,11 +1,10 @@
 [Desktop Entry]
-Encoding=UTF-8
-Name=avidemux2
+Name=Avidemux
 GenericName=Video Editor
 Comment=Multiplatform video editor
-Exec=avidemux2_gtk
+Exec=avidemux3_qt5
 MimeType=video/mpeg;video/quicktime;video/x-msvideo;video/x-anim;audio/x-mp3;audio/x-mp2;
 Icon=avidemux
 Terminal=false
 Type=Application
-Categories=Application;AudioVideo
+Categories=AudioVideo


### PR DESCRIPTION
This updates the file and makes it pass `$ desktop-file-validate avidemux2.desktop` without warnings.

By the way: Avidemux is now available as Flatpak on Flathub:
https://flathub.org/apps/details/org.avidemux.Avidemux
Build manifest:
https://github.com/flathub/org.avidemux.Avidemux