### PR TITLE
Video "Copy" text translation

### DIFF
--- a/avidemux/common/ADM_videoEncoder/src/ADM_dynVideoEncoder.cpp
+++ b/avidemux/common/ADM_videoEncoder/src/ADM_dynVideoEncoder.cpp
@@ -26,8 +26,8 @@
 static int currentVideoCodec=0;
 
 ADM_videoEncoderDesc copyDesc={
-        "Copy",
-        "Copy",
+        QT_TRANSLATE_NOOP("MainWindow", "Copy"), // name
+        QT_TRANSLATE_NOOP("MainWindow", "Copy"), // tag - unused i guess
         "Copy encoder",
         ADM_VIDEO_ENCODER_API_VERSION, //uint32_t     apiVersion;            // const
 


### PR DESCRIPTION
Issue: Copy text in output video combobox (and audio) is replaced by english name.

I'm not sure if this is a good place to implement this.
Because display name is used by functions, the translation should be global (right?).