### PR TITLE
cmake: fix detection of CPUs

### DIFF
--- a/cmake/cmake_compile_check/cpu_armel_check.cpp
+++ b/cmake/cmake_compile_check/cpu_armel_check.cpp
@@ -1,4 +1,4 @@
-int foo(void)
+void foo(void)
 {
 
 	asm volatile ("mov lr,pc " : : );

--- a/cmake/cmake_compile_check/cpu_x86-64_check.cpp
+++ b/cmake/cmake_compile_check/cpu_x86-64_check.cpp
@@ -1,4 +1,4 @@
-int foo(void)
+void foo(void)
 {
 	asm volatile ("movdqa %xmm8, 0");
 }

--- a/cmake/cmake_compile_check/cpu_x86_check.cpp
+++ b/cmake/cmake_compile_check/cpu_x86_check.cpp
@@ -1,4 +1,4 @@
-int foo(void)
+void foo(void)
 {
 	asm volatile ("movdqa %xmm7, 0");
 }


### PR DESCRIPTION
The code defines a function foo returning int, but contains no return.
So the detection fails with "CPU not supported". As new gccs warng abotu
missing return, it causes the detaction to fail. Switch foo to return
void.