### PR TITLE
[ivtcDupeRemover] return true from ivtcDupeRemover::getNextFrame

### DIFF
--- a/avidemux_core/ADM_core/include/ADM_core6_export.h
+++ b/avidemux_core/ADM_core/include/ADM_core6_export.h
@@ -50,4 +50,10 @@
 # define ADM_CORE6_NO_DEPRECATED
 #endif
 
+#ifdef __GNUC__
+#  define ADM_CORE6_NORETURN __attribute__((noreturn))
+#elif defined(_WIN32)
+#  define ADM_CORE6_NORETURN __declspec(noreturn)
+#endif
+
 #endif

--- a/avidemux_core/ADM_core/include/ADM_crashdump.h
+++ b/avidemux_core/ADM_core/include/ADM_crashdump.h
@@ -17,7 +17,7 @@ extern "C"
 	typedef void ADM_fatalFunction(const char *title, const char *info);
         typedef void ADM_sigIntFunction(void);
 
-	ADM_CORE6_EXPORT void ADM_backTrack(const char *info, int lineno, const char *file);
+	ADM_CORE6_EXPORT ADM_CORE6_NORETURN void ADM_backTrack(const char *info, int lineno, const char *file);
 	ADM_CORE6_EXPORT void ADM_setCrashHook(ADM_saveFunction *save, ADM_fatalFunction *fatal,ADM_sigIntFunction *sigint);
 
 #ifdef __cplusplus

--- a/avidemux_core/ADM_core/src/ADM_crashdump_other.cpp
+++ b/avidemux_core/ADM_core/src/ADM_crashdump_other.cpp
@@ -1,4 +1,6 @@
 #include "ADM_crashdump.h"
 
-void ADM_backTrack(const char *info, int lineno, const char *file) { }
+#include <unistd.h>
+
+void ADM_backTrack(const char *info, int lineno, const char *file) { exit(1); }
 void ADM_setCrashHook(ADM_saveFunction *save, ADM_fatalFunction *fatal,ADM_sigIntFunction *other) { }

--- a/avidemux_core/ADM_core/src/ADM_crashdump_unix.cpp
+++ b/avidemux_core/ADM_core/src/ADM_crashdump_unix.cpp
@@ -226,8 +226,10 @@ void ADM_backTrack(const char *info,int lineno,const char *file)
 
 	if(myFatalFunction)
 		myFatalFunction("Crash", wholeStuff); // FIXME
+#else
+	printf("%s\n at line %d, file %s\n",info,lineno,file);
+#endif
         printf("*********** Exiting **************\n");
 	exit(-1); // _exit(1) ???
-#endif
 }
 //EOF


### PR DESCRIPTION
It is declared as returning a bool, but returns nothing. But the callers
expect something to be returned: true in case it succeeded.

**Double check I got it right...**