### PR TITLE
Enable file opening via .desktop

### DIFF
--- a/avidemux/qt4/xdg_data/org.avidemux.Avidemux.desktop
+++ b/avidemux/qt4/xdg_data/org.avidemux.Avidemux.desktop
@@ -2,7 +2,7 @@
 Name=Avidemux
 GenericName=Video Editor
 Comment=Multiplatform video editor
-Exec=avidemux3_qt5
+Exec=avidemux3_qt5 %f
 Icon=org.avidemux.Avidemux
 Terminal=false
 Type=Application


### PR DESCRIPTION
Currently the Avidemux `.desktop` file doesn't enable Avidemux to open files directly from the file manager. Nor can it be set as the default application for opening a filetype, even the ones it supports.

This is due to the lack of a `%f` placeholder on the `Exec=` line of the `.desktop` file. The placeholder is replaced with the filename of the single file to be opened, and if it's not present, GNOME Shell and possibly other environments won't consider an application as having the _ability_ to directly open files.

(I didn't use the `%F` multi-file placeholder because in my testing, attempting to open multiple files  with Avidemux doesn't work. Any additional files listed on the command line after the first are simply ignored, not appended.)

With this change, Avidemux appears in the 'Open file with...' list in GNOME Shell, and it can be set as the default application for any of the filetypes listed in its `MimeTypes=` list.