### PR TITLE
X265 options

### DIFF
--- a/avidemux_plugins/ADM_videoEncoder/x265/ADM_x265.h
+++ b/avidemux_plugins/ADM_videoEncoder/x265/ADM_x265.h
@@ -66,6 +66,7 @@ extern "C"
     40,	/* uint32_t lookahead; */ \
     2, /*    uint32_t weighted_pred */ \
     1, /*    bool weighted_bipred */ \
+    0, /*    bool rect_inter */ \
     0, /*    uint32_t cb_chroma_offset */ \
     0, /*    uint32_t cr_chroma_offset */ \
     3, /*    uint32_t me_method */ \

--- a/avidemux_plugins/ADM_videoEncoder/x265/ADM_x265Setup.cpp
+++ b/avidemux_plugins/ADM_videoEncoder/x265/ADM_x265Setup.cpp
@@ -201,6 +201,7 @@ bool x265Encoder::setup(void)
 
     MKPARAM(bEnableWeightedPred,weighted_pred)
     MKPARAMB(bEnableWeightedBiPred,weighted_bipred)
+    MKPARAMB(bEnableRectInter,rect_inter)
 
     MKPARAMB(bEnableLoopFilter,b_deblocking_filter)
     MKPARAMB(bEnableEarlySkip,fast_pskip)
@@ -363,13 +364,13 @@ void dumpx265Setup(x265_param *param)
     PI(maxNumMergeCand);
     PI(bEnableWeightedPred);
     PI(bEnableWeightedBiPred);
+    PI(bEnableRectInter);
     
     printf("*************************************\n");
     printf("***        Analysis Tools         ***\n");
     printf("*************************************\n");
     
     PI(bEnableAMP);
-    PI(bEnableRectInter);
 #if X265_BUILD < 45
     PI(bEnableCbfFastMode);
 #endif

--- a/avidemux_plugins/ADM_videoEncoder/x265/qt4/Q_x265.cpp
+++ b/avidemux_plugins/ADM_videoEncoder/x265/qt4/Q_x265.cpp
@@ -276,6 +276,7 @@ bool x265Dialog::upload(void)
           toogleAdvancedConfiguration(myCopy.useAdvancedConfiguration);
           MK_CHECKBOX(fastPSkipCheckBox,fast_pskip);
           MK_CHECKBOX(weightedPredictCheckBox,weighted_bipred);
+          MK_CHECKBOX(rectInterCheckBox,rect_inter);
           MK_CHECKBOX(trellisCheckBox,trellis);
           MK_UINT(psychoRdoSpinBox,psy_rd);
           if(myCopy.trellis)
@@ -471,6 +472,7 @@ bool x265Dialog::download(void)
           MK_CHECKBOX(useAdvancedConfigurationCheckBox,useAdvancedConfiguration);
           MK_CHECKBOX(fastPSkipCheckBox,fast_pskip);
           MK_CHECKBOX(weightedPredictCheckBox,weighted_bipred);
+          MK_CHECKBOX(rectInterCheckBox,rect_inter);
 
           if (ui.interlacedCheckBox->isChecked()) {
                   myCopy.interlaced_mode = ui.interlacedComboBox->currentIndex() + 1;

--- a/avidemux_plugins/ADM_videoEncoder/x265/qt4/Q_x265.cpp
+++ b/avidemux_plugins/ADM_videoEncoder/x265/qt4/Q_x265.cpp
@@ -82,7 +82,7 @@ static const aspectRatio predefinedARs[]={
 static const char* listOfPresets[] = { "ultrafast", "superfast", "veryfast", "faster", "fast", "medium", "slow", "slower", "veryslow", "placebo" };
 #define NB_PRESET sizeof(listOfPresets)/sizeof(char*)
 
-static const char* listOfTunings[] = { "none", "psnr", "ssim", "grain", "zerolatency", "fastdecode" };
+static const char* listOfTunings[] = { "none", "psnr", "ssim", "grain", "zerolatency", "fastdecode", "animation" };
 #define NB_TUNE sizeof(listOfTunings)/sizeof(char*)
 
 static const char* listOfProfiles[] = { "main", "main10", "mainstillpicture" };

--- a/avidemux_plugins/ADM_videoEncoder/x265/qt4/x265ConfigDialog.ui
+++ b/avidemux_plugins/ADM_videoEncoder/x265/qt4/x265ConfigDialog.ui
@@ -1227,6 +1227,13 @@
             </property>
            </widget>
           </item>
+          <item row="4" column="0">
+           <widget class="QCheckBox" name="rectInterCheckBox">
+            <property name="text">
+             <string>Rectangular Motion Partitions</string>
+            </property>
+           </widget>
+          </item>
           <item row="1" column="0">
            <layout class="QGridLayout">
             <item row="0" column="0">
@@ -3611,6 +3618,7 @@
   <tabstop>weightedPPredictComboBox</tabstop>
   <tabstop>weightedPredictCheckBox</tabstop>
   <tabstop>constrainedIntraCheckBox</tabstop>
+  <tabstop>rectInterCheckBox</tabstop>
   <tabstop>loopFilterCheckBox</tabstop>
   <tabstop>openGopCheckBox</tabstop>
   <tabstop>interlacedCheckBox</tabstop>

--- a/avidemux_plugins/ADM_videoEncoder/x265/x265_settings.conf
+++ b/avidemux_plugins/ADM_videoEncoder/x265/x265_settings.conf
@@ -28,6 +28,7 @@ bool:constrained_intra;
 uint32_t:lookahead;
 uint32_t:weighted_pred;
 bool:weighted_bipred;
+bool:rect_inter;
 uint32_t:cb_chroma_offset;
 uint32_t:cr_chroma_offset;
 uint32_t:me_method;

--- a/avidemux_plugins/ADM_videoEncoder/x265/x265_settings.h
+++ b/avidemux_plugins/ADM_videoEncoder/x265/x265_settings.h
@@ -31,6 +31,7 @@ bool constrained_intra;
 uint32_t lookahead;
 uint32_t weighted_pred;
 bool weighted_bipred;
+bool rect_inter;
 uint32_t cb_chroma_offset;
 uint32_t cr_chroma_offset;
 uint32_t me_method;

--- a/avidemux_plugins/ADM_videoEncoder/x265/x265_settings_desc.cpp
+++ b/avidemux_plugins/ADM_videoEncoder/x265/x265_settings_desc.cpp
@@ -25,6 +25,7 @@ extern const ADM_paramList x265_settings_param[]={
  {"lookahead",offsetof(x265_settings,lookahead),"uint32_t",ADM_param_uint32_t},
  {"weighted_pred",offsetof(x265_settings,weighted_pred),"uint32_t",ADM_param_uint32_t},
  {"weighted_bipred",offsetof(x265_settings,weighted_bipred),"bool",ADM_param_bool},
+ {"rect_inter",offsetof(x265_settings,rect_inter),"bool",ADM_param_bool},
  {"cb_chroma_offset",offsetof(x265_settings,cb_chroma_offset),"uint32_t",ADM_param_uint32_t},
  {"cr_chroma_offset",offsetof(x265_settings,cr_chroma_offset),"uint32_t",ADM_param_uint32_t},
  {"me_method",offsetof(x265_settings,me_method),"uint32_t",ADM_param_uint32_t},

--- a/avidemux_plugins/ADM_videoEncoder/x265/x265_settings_json.cpp
+++ b/avidemux_plugins/ADM_videoEncoder/x265/x265_settings_json.cpp
@@ -34,6 +34,7 @@ json.addBool("constrained_intra",key->constrained_intra);
 json.addUint32("lookahead",key->lookahead);
 json.addUint32("weighted_pred",key->weighted_pred);
 json.addBool("weighted_bipred",key->weighted_bipred);
+json.addBool("rect_inter",key->rect_inter);
 json.addUint32("cb_chroma_offset",key->cb_chroma_offset);
 json.addUint32("cr_chroma_offset",key->cr_chroma_offset);
 json.addUint32("me_method",key->me_method);


### PR DESCRIPTION
Here are a couple options for x265 that seem useful.

I'd like to be able to duplicate at least the slow preset from x265 in the advanced config, so that it's possible to use slow + extra options.  If I want a longer keyframe interval for 60fps content it's necessary to give up some of options that the x265 authors think are useful enough to include in the preset.