### PR TITLE
X265 options

### DIFF
--- a/avidemux_plugins/ADM_videoEncoder/x265/ADM_x265.h
+++ b/avidemux_plugins/ADM_videoEncoder/x265/ADM_x265.h
@@ -73,6 +73,7 @@ extern "C"
     3, /*    uint32_t me_method */ \
     16, /*   uint32_t me_range */ \
     5, /*    uint32_t subpel_refine */ \
+    0x03, /* uint32_t limit_refs */ \
     1, /*    uint32_t trellis */ \
     3, /*       uint32_t rd_level */ \
     1.0, /*     float psy_rd */ \

--- a/avidemux_plugins/ADM_videoEncoder/x265/ADM_x265.h
+++ b/avidemux_plugins/ADM_videoEncoder/x265/ADM_x265.h
@@ -74,6 +74,7 @@ extern "C"
     16, /*   uint32_t me_range */ \
     5, /*    uint32_t subpel_refine */ \
     1, /*    uint32_t trellis */ \
+    3, /*       uint32_t rd_level */ \
     1.0, /*     float psy_rd */ \
     true, /*    bool fast_pskip */ \
     true, /*    bool dct_decimate */ \

--- a/avidemux_plugins/ADM_videoEncoder/x265/ADM_x265.h
+++ b/avidemux_plugins/ADM_videoEncoder/x265/ADM_x265.h
@@ -63,6 +63,7 @@ extern "C"
     1, /* bool b_open_gop */ \
     0, /* uint32_t interlaced_mode */ \
     false, /* bool constrained_intra */ \
+    true, /* bool b_intra */ \
     40,	/* uint32_t lookahead; */ \
     2, /*    uint32_t weighted_pred */ \
     1, /*    bool weighted_bipred */ \

--- a/avidemux_plugins/ADM_videoEncoder/x265/ADM_x265Setup.cpp
+++ b/avidemux_plugins/ADM_videoEncoder/x265/ADM_x265Setup.cpp
@@ -194,6 +194,7 @@ bool x265Encoder::setup(void)
     MKPARAM(lookaheadDepth,lookahead)
     MKPARAM(scenecutThreshold,i_scenecut_threshold)
     MKPARAMB(bEnableConstrainedIntra,constrained_intra)
+    MKPARAMB(bIntraInBFrames,b_intra)
 
     MKPARAM(searchMethod,me_method)
     MKPARAM(subpelRefine,subpel_refine)
@@ -352,6 +353,7 @@ void dumpx265Setup(x265_param *param)
     printf("*************************************\n");
     
     PI(bEnableConstrainedIntra);
+    PI(bIntraInBFrames);
     PI(bEnableStrongIntraSmoothing);
     
     printf("*************************************\n");
@@ -401,7 +403,6 @@ void dumpx265Setup(x265_param *param)
     
     PI(cbQpOffset);
     PI(crQpOffset);
-    PI(bIntraInBFrames);
     
 #if X265_BUILD >= 40
     PI(noiseReductionIntra);

--- a/avidemux_plugins/ADM_videoEncoder/x265/ADM_x265Setup.cpp
+++ b/avidemux_plugins/ADM_videoEncoder/x265/ADM_x265Setup.cpp
@@ -199,6 +199,7 @@ bool x265Encoder::setup(void)
     MKPARAM(searchMethod,me_method)
     MKPARAM(subpelRefine,subpel_refine)
     MKPARAM(searchRange,me_range)
+    MKPARAM(limitReferences,limit_refs)
 
     MKPARAM(bEnableWeightedPred,weighted_pred)
     MKPARAMB(bEnableWeightedBiPred,weighted_bipred)
@@ -365,6 +366,7 @@ void dumpx265Setup(x265_param *param)
     PI(subpelRefine);
     PI(searchRange);
     PI(maxNumMergeCand);
+    PI(limitReferences);
     PI(bEnableWeightedPred);
     PI(bEnableWeightedBiPred);
     PI(bEnableRectInter);

--- a/avidemux_plugins/ADM_videoEncoder/x265/ADM_x265Setup.cpp
+++ b/avidemux_plugins/ADM_videoEncoder/x265/ADM_x265Setup.cpp
@@ -208,6 +208,7 @@ bool x265Encoder::setup(void)
     MKPARAMB(bEnableEarlySkip,fast_pskip)
     MKPARAMB(bEnableTSkipFast,dct_decimate)
 
+    MKPARAM (rdLevel,rd_level)
     MKPARAMD(psyRd,psy_rd)
     MKPARAM (cbQpOffset,cb_chroma_offset)
     MKPARAM (crQpOffset,cr_chroma_offset)

--- a/avidemux_plugins/ADM_videoEncoder/x265/qt4/Q_x265.cpp
+++ b/avidemux_plugins/ADM_videoEncoder/x265/qt4/Q_x265.cpp
@@ -324,6 +324,7 @@ bool x265Dialog::upload(void)
           MK_MENU(bFrameRefComboBox,i_bframe_pyramid);
           MK_MENU(adaptiveBFrameComboBox,i_bframe_adaptive);
           MK_CHECKBOX(constrainedIntraCheckBox,constrained_intra);
+          MK_CHECKBOX(bIntraCheckBox,b_intra);
 
           MK_UINT(mvRangeSpinBox,me_range);
 
@@ -495,6 +496,7 @@ bool x265Dialog::download(void)
           MK_MENU(bFrameRefComboBox,i_bframe_pyramid);
           MK_MENU(adaptiveBFrameComboBox,i_bframe_adaptive);
           MK_CHECKBOX(constrainedIntraCheckBox,constrained_intra);
+          MK_CHECKBOX(bIntraCheckBox,b_intra);
 
           MK_UINT(quantiserMaxStepSpinBox,ratecontrol.qp_step);
           

--- a/avidemux_plugins/ADM_videoEncoder/x265/qt4/Q_x265.cpp
+++ b/avidemux_plugins/ADM_videoEncoder/x265/qt4/Q_x265.cpp
@@ -121,6 +121,7 @@ x265Dialog::x265Dialog(QWidget *parent, void *param) : QDialog(parent)
         connect(ui.quantiserSlider, SIGNAL(valueChanged(int)), this, SLOT(quantiserSlider_valueChanged(int)));
         connect(ui.meSlider, SIGNAL(valueChanged(int)), this, SLOT(meSlider_valueChanged(int)));
         connect(ui.quantiserSpinBox, SIGNAL(valueChanged(int)), this, SLOT(quantiserSpinBox_valueChanged(int)));
+        connect(ui.refFramesSpinBox, SIGNAL(valueChanged(int)), this, SLOT(refFramesSpinBox_valueChanged(int)));
         connect(ui.maxBFramesSpinBox, SIGNAL(valueChanged(int)), this, SLOT(maxBFramesSpinBox_valueChanged(int)));
         connect(ui.bFrameRefComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(bFrameRefComboBox_currentIndexChanged(int)));
         connect(ui.meSpinBox, SIGNAL(valueChanged(int)), this, SLOT(meSpinBox_valueChanged(int)));
@@ -296,6 +297,8 @@ bool x265Dialog::upload(void)
 
           MK_UINT(maxBFramesSpinBox,MaxBFrame);
           MK_UINT(refFramesSpinBox,MaxRefFrames);
+          MK_CHECKBOX(limitRefDepthCheckBox,limit_refs & X265_REF_LIMIT_DEPTH);
+          MK_CHECKBOX(limitRefCUCheckBox,limit_refs & X265_REF_LIMIT_CU);
           MK_UINT(minGopSizeSpinBox,MinIdr);
           MK_UINT(maxGopSizeSpinBox,MaxIdr);
           MK_UINT(IFrameThresholdSpinBox,i_scenecut_threshold);
@@ -486,6 +489,8 @@ bool x265Dialog::download(void)
 
           MK_UINT(maxBFramesSpinBox,MaxBFrame);
           MK_UINT(refFramesSpinBox,MaxRefFrames);
+          myCopy.limit_refs = (ui.limitRefDepthCheckBox->isChecked() ? X265_REF_LIMIT_DEPTH : 0) |
+                              (ui.limitRefCUCheckBox->isChecked() ? X265_REF_LIMIT_CU : 0);
           MK_UINT(minGopSizeSpinBox,MinIdr);
           MK_UINT(maxGopSizeSpinBox,MaxIdr);
           MK_UINT(IFrameThresholdSpinBox,i_scenecut_threshold);
@@ -666,6 +671,14 @@ void x265Dialog::meSlider_valueChanged(int value)
 void x265Dialog::quantiserSpinBox_valueChanged(int value)
 {
 	ui.quantiserSlider->setValue(value);
+}
+
+void x265Dialog::refFramesSpinBox_valueChanged(int value)
+{
+    // Limiting reference frames doesn't have an effect when they are already limited to 1
+    const bool enable = value > 1;
+    ui.limitRefDepthCheckBox->setEnabled(enable);
+    ui.limitRefCUCheckBox->setEnabled(enable);
 }
 
 void x265Dialog::maxBFramesSpinBox_valueChanged(int value)

--- a/avidemux_plugins/ADM_videoEncoder/x265/qt4/Q_x265.cpp
+++ b/avidemux_plugins/ADM_videoEncoder/x265/qt4/Q_x265.cpp
@@ -278,6 +278,7 @@ bool x265Dialog::upload(void)
           MK_CHECKBOX(weightedPredictCheckBox,weighted_bipred);
           MK_CHECKBOX(rectInterCheckBox,rect_inter);
           MK_CHECKBOX(trellisCheckBox,trellis);
+          MK_UINT(rdoSpinBox,rd_level);
           MK_UINT(psychoRdoSpinBox,psy_rd);
           if(myCopy.trellis)
           {
@@ -529,6 +530,7 @@ bool x265Dialog::download(void)
 
           MK_UINT(mvRangeSpinBox,me_range);
 
+          MK_UINT(rdoSpinBox,rd_level);
           MK_UINT(psychoRdoSpinBox,psy_rd);
           
 #if X265_BUILD >= 40

--- a/avidemux_plugins/ADM_videoEncoder/x265/qt4/Q_x265.h
+++ b/avidemux_plugins/ADM_videoEncoder/x265/qt4/Q_x265.h
@@ -38,6 +38,7 @@ private slots:
         void useAdvancedConfigurationCheckBox_toggled(bool checked);
         void meSpinBox_valueChanged(int value);
         void meSlider_valueChanged(int value);
+        void refFramesSpinBox_valueChanged(int value);
         void maxBFramesSpinBox_valueChanged(int value);
         void bFrameRefComboBox_currentIndexChanged(int index);
         void encodingModeComboBox_currentIndexChanged(int index);

--- a/avidemux_plugins/ADM_videoEncoder/x265/qt4/x265ConfigDialog.ui
+++ b/avidemux_plugins/ADM_videoEncoder/x265/qt4/x265ConfigDialog.ui
@@ -1426,6 +1426,27 @@
               </item>
              </layout>
             </item>
+            <item>
+             <widget class="QLabel" name="label_56">
+              <property name="text">
+               <string>Limit References by:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="limitRefCUCheckBox">
+              <property name="text">
+               <string>CU</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="limitRefDepthCheckBox">
+              <property name="text">
+               <string>Depth</string>
+              </property>
+             </widget>
+            </item>
            </layout>
           </item>
          </layout>
@@ -3681,6 +3702,8 @@
   <tabstop>interlacedCheckBox</tabstop>
   <tabstop>interlacedComboBox</tabstop>
   <tabstop>refFramesSpinBox</tabstop>
+  <tabstop>limitRefCUCheckBox</tabstop>
+  <tabstop>limitRefDepthCheckBox</tabstop>
   <tabstop>maxBFramesSpinBox</tabstop>
   <tabstop>BFrameBiasSpinBox</tabstop>
   <tabstop>adaptiveBFrameComboBox</tabstop>

--- a/avidemux_plugins/ADM_videoEncoder/x265/qt4/x265ConfigDialog.ui
+++ b/avidemux_plugins/ADM_videoEncoder/x265/qt4/x265ConfigDialog.ui
@@ -1796,9 +1796,47 @@
           <item>
            <layout class="QHBoxLayout" name="horizontalLayout_5">
             <item>
+             <widget class="QLabel" name="lblRDO">
+              <property name="text">
+               <string>Rate Distortion Optimisation:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_15">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+             </spacer>
+            </item>
+            <item>
              <widget class="QLabel" name="lblPsychoRDO">
               <property name="text">
-               <string>Psychovisual Rate Distortion Optimisation:</string>
+               <string>Level:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="rdoSpinBox">
+              <property name="minimum">
+               <number>1</number>
+              </property>
+              <property name="maximum">
+               <number>6</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_16">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QLabel" name="lblRDOLevel">
+              <property name="text">
+               <string>Psycho-visual Strength:</string>
               </property>
              </widget>
             </item>
@@ -3654,6 +3692,7 @@
   <tabstop>trellisComboBox</tabstop>
   <tabstop>fastPSkipCheckBox</tabstop>
   <tabstop>dctDecimateCheckBox</tabstop>
+  <tabstop>rdoSpinBox</tabstop>
   <tabstop>psychoRdoSpinBox</tabstop>
   <tabstop>noiseReductionSpinBox</tabstop>
   <tabstop>matrixFlatRadioButton</tabstop>

--- a/avidemux_plugins/ADM_videoEncoder/x265/qt4/x265ConfigDialog.ui
+++ b/avidemux_plugins/ADM_videoEncoder/x265/qt4/x265ConfigDialog.ui
@@ -1214,11 +1214,29 @@
          </property>
          <layout class="QGridLayout">
           <item row="2" column="0">
-           <widget class="QCheckBox" name="weightedPredictCheckBox">
-            <property name="text">
-             <string>Weighted Prediction for B-frames</string>
-            </property>
-           </widget>
+           <layout class="QGridLayout">
+            <item row="0" column="0">
+             <widget class="QLabel" name="lblBPredict">
+              <property name="text">
+               <string>Prediction for B-frames:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QCheckBox" name="weightedPredictCheckBox">
+              <property name="text">
+               <string>Weighted Prediction</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QCheckBox" name="bIntraCheckBox">
+              <property name="text">
+               <string>Intra Prediction</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item row="3" column="0">
            <widget class="QCheckBox" name="constrainedIntraCheckBox">
@@ -3618,6 +3636,7 @@
   <tabstop>weightedPPredictComboBox</tabstop>
   <tabstop>weightedPredictCheckBox</tabstop>
   <tabstop>constrainedIntraCheckBox</tabstop>
+  <tabstop>bIntraCheckBox</tabstop>
   <tabstop>rectInterCheckBox</tabstop>
   <tabstop>loopFilterCheckBox</tabstop>
   <tabstop>openGopCheckBox</tabstop>

--- a/avidemux_plugins/ADM_videoEncoder/x265/x265_settings.conf
+++ b/avidemux_plugins/ADM_videoEncoder/x265/x265_settings.conf
@@ -35,6 +35,7 @@ uint32_t:cr_chroma_offset;
 uint32_t:me_method;
 uint32_t:me_range;
 uint32_t:subpel_refine;
+uint32_t:limit_refs;
 uint32_t:trellis;
 uint32_t:rd_level;
 double:psy_rd;

--- a/avidemux_plugins/ADM_videoEncoder/x265/x265_settings.conf
+++ b/avidemux_plugins/ADM_videoEncoder/x265/x265_settings.conf
@@ -25,6 +25,7 @@ bool:b_deblocking_filter;
 bool:b_open_gop;
 uint32_t:interlaced_mode;
 bool:constrained_intra;
+bool:b_intra;
 uint32_t:lookahead;
 uint32_t:weighted_pred;
 bool:weighted_bipred;

--- a/avidemux_plugins/ADM_videoEncoder/x265/x265_settings.conf
+++ b/avidemux_plugins/ADM_videoEncoder/x265/x265_settings.conf
@@ -36,6 +36,7 @@ uint32_t:me_method;
 uint32_t:me_range;
 uint32_t:subpel_refine;
 uint32_t:trellis;
+uint32_t:rd_level;
 double:psy_rd;
 bool:fast_pskip;
 bool:dct_decimate;

--- a/avidemux_plugins/ADM_videoEncoder/x265/x265_settings.h
+++ b/avidemux_plugins/ADM_videoEncoder/x265/x265_settings.h
@@ -39,6 +39,7 @@ uint32_t me_method;
 uint32_t me_range;
 uint32_t subpel_refine;
 uint32_t trellis;
+uint32_t rd_level;
 double psy_rd;
 bool fast_pskip;
 bool dct_decimate;

--- a/avidemux_plugins/ADM_videoEncoder/x265/x265_settings.h
+++ b/avidemux_plugins/ADM_videoEncoder/x265/x265_settings.h
@@ -28,6 +28,7 @@ bool b_deblocking_filter;
 bool b_open_gop;
 uint32_t interlaced_mode;
 bool constrained_intra;
+bool b_intra;
 uint32_t lookahead;
 uint32_t weighted_pred;
 bool weighted_bipred;

--- a/avidemux_plugins/ADM_videoEncoder/x265/x265_settings.h
+++ b/avidemux_plugins/ADM_videoEncoder/x265/x265_settings.h
@@ -38,6 +38,7 @@ uint32_t cr_chroma_offset;
 uint32_t me_method;
 uint32_t me_range;
 uint32_t subpel_refine;
+uint32_t limit_refs;
 uint32_t trellis;
 uint32_t rd_level;
 double psy_rd;

--- a/avidemux_plugins/ADM_videoEncoder/x265/x265_settings_desc.cpp
+++ b/avidemux_plugins/ADM_videoEncoder/x265/x265_settings_desc.cpp
@@ -33,6 +33,7 @@ extern const ADM_paramList x265_settings_param[]={
  {"me_range",offsetof(x265_settings,me_range),"uint32_t",ADM_param_uint32_t},
  {"subpel_refine",offsetof(x265_settings,subpel_refine),"uint32_t",ADM_param_uint32_t},
  {"trellis",offsetof(x265_settings,trellis),"uint32_t",ADM_param_uint32_t},
+ {"rd_level",offsetof(x265_settings,rd_level),"uint32_t",ADM_param_uint32_t},
  {"psy_rd",offsetof(x265_settings,psy_rd),"double",ADM_param_double},
  {"fast_pskip",offsetof(x265_settings,fast_pskip),"bool",ADM_param_bool},
  {"dct_decimate",offsetof(x265_settings,dct_decimate),"bool",ADM_param_bool},

--- a/avidemux_plugins/ADM_videoEncoder/x265/x265_settings_desc.cpp
+++ b/avidemux_plugins/ADM_videoEncoder/x265/x265_settings_desc.cpp
@@ -32,6 +32,7 @@ extern const ADM_paramList x265_settings_param[]={
  {"me_method",offsetof(x265_settings,me_method),"uint32_t",ADM_param_uint32_t},
  {"me_range",offsetof(x265_settings,me_range),"uint32_t",ADM_param_uint32_t},
  {"subpel_refine",offsetof(x265_settings,subpel_refine),"uint32_t",ADM_param_uint32_t},
+ {"limit_refs",offsetof(x265_settings,limit_refs),"uint32_t",ADM_param_uint32_t},
  {"trellis",offsetof(x265_settings,trellis),"uint32_t",ADM_param_uint32_t},
  {"rd_level",offsetof(x265_settings,rd_level),"uint32_t",ADM_param_uint32_t},
  {"psy_rd",offsetof(x265_settings,psy_rd),"double",ADM_param_double},

--- a/avidemux_plugins/ADM_videoEncoder/x265/x265_settings_desc.cpp
+++ b/avidemux_plugins/ADM_videoEncoder/x265/x265_settings_desc.cpp
@@ -22,6 +22,7 @@ extern const ADM_paramList x265_settings_param[]={
  {"b_open_gop",offsetof(x265_settings,b_open_gop),"bool",ADM_param_bool},
  {"interlaced_mode",offsetof(x265_settings,interlaced_mode),"uint32_t",ADM_param_uint32_t},
  {"constrained_intra",offsetof(x265_settings,constrained_intra),"bool",ADM_param_bool},
+ {"b_intra",offsetof(x265_settings,b_intra),"bool",ADM_param_bool},
  {"lookahead",offsetof(x265_settings,lookahead),"uint32_t",ADM_param_uint32_t},
  {"weighted_pred",offsetof(x265_settings,weighted_pred),"uint32_t",ADM_param_uint32_t},
  {"weighted_bipred",offsetof(x265_settings,weighted_bipred),"bool",ADM_param_bool},

--- a/avidemux_plugins/ADM_videoEncoder/x265/x265_settings_json.cpp
+++ b/avidemux_plugins/ADM_videoEncoder/x265/x265_settings_json.cpp
@@ -42,6 +42,7 @@ json.addUint32("me_method",key->me_method);
 json.addUint32("me_range",key->me_range);
 json.addUint32("subpel_refine",key->subpel_refine);
 json.addUint32("trellis",key->trellis);
+json.addUint32("rd_level",key->rd_level);
 json.addDouble("psy_rd",key->psy_rd);
 json.addBool("fast_pskip",key->fast_pskip);
 json.addBool("dct_decimate",key->dct_decimate);

--- a/avidemux_plugins/ADM_videoEncoder/x265/x265_settings_json.cpp
+++ b/avidemux_plugins/ADM_videoEncoder/x265/x265_settings_json.cpp
@@ -31,6 +31,7 @@ json.addBool("b_deblocking_filter",key->b_deblocking_filter);
 json.addBool("b_open_gop",key->b_open_gop);
 json.addUint32("interlaced_mode",key->interlaced_mode);
 json.addBool("constrained_intra",key->constrained_intra);
+json.addBool("b_intra",key->b_intra);
 json.addUint32("lookahead",key->lookahead);
 json.addUint32("weighted_pred",key->weighted_pred);
 json.addBool("weighted_bipred",key->weighted_bipred);

--- a/avidemux_plugins/ADM_videoEncoder/x265/x265_settings_json.cpp
+++ b/avidemux_plugins/ADM_videoEncoder/x265/x265_settings_json.cpp
@@ -41,6 +41,7 @@ json.addUint32("cr_chroma_offset",key->cr_chroma_offset);
 json.addUint32("me_method",key->me_method);
 json.addUint32("me_range",key->me_range);
 json.addUint32("subpel_refine",key->subpel_refine);
+json.addUint32("limit_refs",key->limit_refs);
 json.addUint32("trellis",key->trellis);
 json.addUint32("rd_level",key->rd_level);
 json.addDouble("psy_rd",key->psy_rd);


### PR DESCRIPTION
More options for x265 to allow at least the slow preset to be configured.  There are still some more to fully get slow, and tons more total, but I think probably the options used in the presets area really worth adding.

I've tested this with x265 3.3 and they appear to work as expected.  I think all these options have been x265 for a number a versions, but I haven't gone back and found out how long.