### PR TITLE
Allow choice of executable in AppImage

### DIFF
--- a/appImage/AppRunBuster
+++ b/appImage/AppRunBuster
@@ -16,6 +16,14 @@ then
     exit 1
 fi
 
+# make relative-path arguments absolute before changing directory
+args=("--portable");
+paramprefix="--";
+for arg in "$@";
+do # add argument as is, or realpath of argument, depending on paramprefix
+	[ "${arg::2}" != "$paramprefix" -o -e "$arg" ] && args+=("$(realpath -- "$arg")") || args+=("$arg");
+	[ "$arg" == "$paramprefix" ] && paramprefix="123"; # new paramprefix will never match length-2 string
+done;
 HERE="$(dirname "$(readlink -f "${0}")")"
 cd "${HERE}/usr/"
 export QT_STYLE_OVERRIDE="fusion"
@@ -52,6 +60,12 @@ fi
 
 export LD_LIBRARY_PATH="${HERE}/usr/lib/:${HERE}/usr/lib/qt5:${LD_LIBRARY_PATH}"
 export PATH="${HERE}/usr/bin:${PATH}"
-"${HERE}/usr/bin/avidemux3_qt5" --portable "$@"
+# choose binary depending on substrings "_jobs" or "_cli" in the name appImage is called by
+if [[ "${ARGV0##*/}" =~ _jobs ]]
+then "${HERE}/usr/bin/avidemux3_jobs_qt5" "${args[@]}"
+elif [[ "${ARGV0##*/}" =~ _cli ]]
+then "${HERE}/usr/bin/avidemux3_cli" "${args[@]}"
+else "${HERE}/usr/bin/avidemux3_qt5" "${args[@]}"
+fi
 cd -
 

--- a/appImage/AppRunBuster
+++ b/appImage/AppRunBuster
@@ -19,10 +19,18 @@ fi
 # make relative-path arguments absolute before changing directory
 args=("--portable");
 paramprefix="--";
+param="--load";#enable filename to load as first/single argument
 for arg in "$@";
 do # add argument as is, or realpath of argument, depending on paramprefix
-	[ "${arg::2}" != "$paramprefix" -o -e "$arg" ] && args+=("$(realpath -- "$arg")") || args+=("$arg");
-	[ "$arg" == "$paramprefix" ] && paramprefix="123"; # new paramprefix will never match length-2 string
+	[ "${arg::2}" = "$paramprefix" ] && args+=("$arg") && param="$arg" || {
+		case "$param" in
+		--append|--load|--run|--save*)
+			args+=("$(realpath -- "$arg")") ;;
+		*)
+			args+=("$arg") ;;
+		esac
+	}
+	[ "$arg" == "$paramprefix" ] && paramprefix="123" && param=""; # new paramprefix will never match length-2 string again
 done;
 HERE="$(dirname "$(readlink -f "${0}")")"
 cd "${HERE}/usr/"

--- a/appImage/AppRunBuster
+++ b/appImage/AppRunBuster
@@ -19,7 +19,7 @@ fi
 # make relative-path arguments absolute before changing directory
 args=("--portable");
 paramprefix="--";
-param="--load";#enable filename to load as first/single argument
+param="--load";#enable filename as first/single argument, with --load as supposed default action
 for arg in "$@";
 do # add argument as is, or realpath of argument, depending on paramprefix
 	[ "${arg::2}" = "$paramprefix" ] && args+=("$arg") && param="$arg" || {
@@ -30,7 +30,7 @@ do # add argument as is, or realpath of argument, depending on paramprefix
 			args+=("$arg") ;;
 		esac
 	}
-	[ "$arg" == "$paramprefix" ] && paramprefix="123" && param=""; # new paramprefix will never match length-2 string again
+	[ "$arg" == "$paramprefix" ] && paramprefix="123" && param="--load"; # new paramprefix will never match length-2 string again
 done;
 HERE="$(dirname "$(readlink -f "${0}")")"
 cd "${HERE}/usr/"

--- a/makeAppImageBusterMinimal.sh
+++ b/makeAppImageBusterMinimal.sh
@@ -174,7 +174,7 @@ rm -rf install > /dev/null 2>&1
 
 export CXXFLAGS="$CXXFLAGS -std=c++11"
 logfile="/tmp/log-bootstrap-$(date +%F_%T).log"
-bash bootStrap.bash --with-system-libass --with-system-libmad --without-cli ${rebuild} 2>&1 | tee ${logfile}
+bash bootStrap.bash --with-system-libass --with-system-libmad ${rebuild} 2>&1 | tee ${logfile}
 if [ ${PIPESTATUS[0]} -ne 0 ]; then
     fail "Build failed, please inspect ${logfile} and /tmp/logbuild* files."
 fi


### PR DESCRIPTION
1. Because of the patch with sed in deployBusterMinimal.sh, to replace all absolute paths to `/usr` by relative paths `././` and thelike, AppRunBuster has to change directory to `"${HERE}/usr"`, which it indeed does. But then `"$@"` should be run through a loop to replace relative path or filename arguments in it by their `"realpath"`.

2. The new AppImage runtime passes a variable `ARGV0` to AppRun, which is set to the name/path used to execute the AppImage (for example the name of a symbolic link to the actual AppImage file). That way, if a user or his admin makes three symbolic links to the appImage file, let's say as `avidemux`, `avidemux_jobs`, and `avidemux_cli` (with or without versions in the name), the AppRun script can detect the suffix used, and call the corresponding binary.

3. This pull request should go with an instruction to the AppImage user, or his admin, to place symbolic links to the AppImage file. If the AppImage file is executed without symbolic link, avidemux3_qt5 is executed. If the symbolic link contains the substring "_jobs", avidemux3_jobs_qt5 is executed; else if the symbolic link contains the substring "_cli", avidemux3_cli is executed; else avidemux3_qt5 is executed.