### PR TITLE
[demuxers/MpegTS] Fix for 60000/1001 framerate

### DIFF
--- a/avidemux_plugins/ADM_demuxers/MpegTS/ADM_tsReadIndex.cpp
+++ b/avidemux_plugins/ADM_demuxers/MpegTS/ADM_tsReadIndex.cpp
@@ -285,6 +285,10 @@ bool    tsHeader::readVideo(indexFile *index)
             _videostream.dwScale=1001;
             _videostream.dwRate=30000;
             break;
+	case 59940:
+            _videostream.dwScale=1001;
+            _videostream.dwRate=60000;
+            break;
         case 24000:
         case 25000:
         case 30000:


### PR DESCRIPTION
The ts.idx2 file stores framerate as fps * 1000, instead of a rational
number with an integer number and denominator, which would be much
better.

It must then convert that back into a rational so it can put inside a
fake AVI header.

It does not use a closest rational approximation algorithm but just hard
codes a few different common frame rates.  And the standard ATSC rate of
60000/1001 was not in the list.  So add it.