### PR TITLE
Increased editor cache size default and upper limit

### DIFF
--- a/avidemux/common/ADM_commonUI/DIA_prefs.cpp
+++ b/avidemux/common/ADM_commonUI/DIA_prefs.cpp
@@ -315,7 +315,7 @@ std::string currentSdlDriver=getSdlDriverName();
         multiLoadUseCustomFragmentSize.link(1,&multiLoadCustomFragmentSize);
 
         diaElemFrame frameCache(QT_TRANSLATE_NOOP("adm","Caching of decoded pictures"));
-        diaElemUInteger cacheSize(&editor_cache_size,QT_TRANSLATE_NOOP("adm","_Cache size:"),8,16);
+        diaElemUInteger cacheSize(&editor_cache_size,QT_TRANSLATE_NOOP("adm","_Cache size:"),8,255);
         frameCache.swallow(&cacheSize);
 
         diaMenuEntry videoMode[]={

--- a/avidemux/common/ADM_editor/include/ADM_edCache.h
+++ b/avidemux/common/ADM_editor/include/ADM_edCache.h
@@ -16,7 +16,7 @@
 #define ADM_IN_USE_CACHE  0xfffe
 
 #define EDITOR_CACHE_MIN_SIZE 8
-#define EDITOR_CACHE_MAX_SIZE 16
+#define EDITOR_CACHE_MAX_SIZE 255
 
 typedef struct cacheElem
 {

--- a/avidemux_core/ADM_coreUtils/src/prefs2_pref.h
+++ b/avidemux_core/ADM_coreUtils/src/prefs2_pref.h
@@ -19,7 +19,7 @@ static optionDesc myOptions[]={
 { FEATURES_AUDIOBAR_USES_MASTER,"features.audiobar_uses_master"       ,ADM_param_bool    	,"0",	0,	1},
 { FEATURES_THREADING_LAVC,"features.threading_lavc"                   ,ADM_param_uint32_t	,"0",	0,	32},
 { FEATURES_CPU_CAPS,"features.cpu_caps"                               ,ADM_param_uint32_t	,"4294967295",	0,	4294967295},
-{ FEATURES_CACHE_SIZE,"features.cache_size"                           ,ADM_param_uint32_t	,"16",	8,	16},
+{ FEATURES_CACHE_SIZE,"features.cache_size"                           ,ADM_param_uint32_t	,"60",	8,	255},
 { FEATURES_MPEG_NO_LIMIT,"features.mpeg_no_limit"                     ,ADM_param_bool    	,"0",	0,	1},
 { FEATURES_DXVA2,"features.dxva2"                                     ,ADM_param_bool    	,"0",	0,	1},
 { FEATURES_DXVA2_OVERRIDE_BLACKLIST_VERSION,"features.dxva2_override_blacklist_version",ADM_param_bool    	,"0",	0,	1},

--- a/avidemux_core/ADM_coreUtils/src/prefs2_pref.h
+++ b/avidemux_core/ADM_coreUtils/src/prefs2_pref.h
@@ -19,7 +19,7 @@ static optionDesc myOptions[]={
 { FEATURES_AUDIOBAR_USES_MASTER,"features.audiobar_uses_master"       ,ADM_param_bool    	,"0",	0,	1},
 { FEATURES_THREADING_LAVC,"features.threading_lavc"                   ,ADM_param_uint32_t	,"0",	0,	32},
 { FEATURES_CPU_CAPS,"features.cpu_caps"                               ,ADM_param_uint32_t	,"4294967295",	0,	4294967295},
-{ FEATURES_CACHE_SIZE,"features.cache_size"                           ,ADM_param_uint32_t	,"60",	8,	255},
+{ FEATURES_CACHE_SIZE,"features.cache_size"                           ,ADM_param_uint32_t	,"16",	8,	255},
 { FEATURES_MPEG_NO_LIMIT,"features.mpeg_no_limit"                     ,ADM_param_bool    	,"0",	0,	1},
 { FEATURES_DXVA2,"features.dxva2"                                     ,ADM_param_bool    	,"0",	0,	1},
 { FEATURES_DXVA2_OVERRIDE_BLACKLIST_VERSION,"features.dxva2_override_blacklist_version",ADM_param_bool    	,"0",	0,	1},


### PR DESCRIPTION
Hi!

Editing high demanding contents (eg. 4k 60fps or more) is very painfull, especially when searching for cutting point in the video.
Due to the default (and until now upper limit) 16 frames editor cache size, while navigating in the video, it will constantly re decode the video frames, therefore it cause a major slowdown during editing.

In this commit i increased the upper limit to 255 frames, and the default value to 60 frames.