### PR TITLE
Crop filter keep aspect ratio option

### DIFF
--- a/avidemux_plugins/ADM_videoFilters6/crop/ADM_vidCrop.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/crop/ADM_vidCrop.cpp
@@ -74,6 +74,7 @@ CropFilter::CropFilter(ADM_coreVideoFilter *in,CONFcouple *couples) :ADM_coreVid
             configuration.left=0;
             configuration.right=0;
             configuration.rubber_is_hidden=false;
+            configuration.keep_aspect=false;
         }
         if(  in->getInfo()->width<(configuration.right+configuration.left))
                 {

--- a/avidemux_plugins/ADM_videoFilters6/crop/crop.conf
+++ b/avidemux_plugins/ADM_videoFilters6/crop/crop.conf
@@ -4,4 +4,5 @@ uint32_t:bottom
 uint32_t:left
 uint32_t:right
 bool:rubber_is_hidden
+bool:keep_aspect
 }

--- a/avidemux_plugins/ADM_videoFilters6/crop/crop.h
+++ b/avidemux_plugins/ADM_videoFilters6/crop/crop.h
@@ -7,4 +7,5 @@ uint32_t bottom;
 uint32_t left;
 uint32_t right;
 bool rubber_is_hidden;
+bool keep_aspect;
 }crop;

--- a/avidemux_plugins/ADM_videoFilters6/crop/crop_desc.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/crop/crop_desc.cpp
@@ -5,5 +5,6 @@ extern const ADM_paramList crop_param[]={
  {"left",offsetof(crop,left),"uint32_t",ADM_param_uint32_t},
  {"right",offsetof(crop,right),"uint32_t",ADM_param_uint32_t},
  {"rubber_is_hidden",offsetof(crop,rubber_is_hidden),"bool",ADM_param_bool},
+ {"keep_aspect",offsetof(crop,keep_aspect),"bool",ADM_param_bool},
 {NULL,0,NULL}
 };

--- a/avidemux_plugins/ADM_videoFilters6/crop/qt5/DIA_flyCrop.h
+++ b/avidemux_plugins/ADM_videoFilters6/crop/qt5/DIA_flyCrop.h
@@ -8,6 +8,7 @@ class flyCrop : public ADM_flyDialogRgb
   public:
    uint32_t left,right,top,bottom;
    bool rubber_is_hidden;
+   bool keep_aspect;
   public:
    uint8_t    processRgb(uint8_t *imageIn, uint8_t *imageOut);
    uint8_t    download(void) {return download(false);}

--- a/avidemux_plugins/ADM_videoFilters6/crop/qt5/Q_crop.h
+++ b/avidemux_plugins/ADM_videoFilters6/crop/qt5/Q_crop.h
@@ -38,6 +38,7 @@ private slots:
 	void autoCrop(bool f);
 	void reset(bool f);
 	void toggleRubber(int checkState);
+	void toggleKeepAspect(int checkState);
 
 private:
         void resizeEvent(QResizeEvent *event);

--- a/avidemux_plugins/ADM_videoFilters6/crop/qt5/crop.ui
+++ b/avidemux_plugins/ADM_videoFilters6/crop/qt5/crop.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>600</width>
+    <width>781</width>
     <height>300</height>
    </rect>
   </property>
@@ -46,7 +46,7 @@
      <property name="spacing">
       <number>6</number>
      </property>
-     <item row="1" column="8">
+     <item row="1" column="9">
       <widget class="QPushButton" name="pushButtonReset">
        <property name="text">
         <string>Reset</string>
@@ -127,7 +127,7 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="8">
+     <item row="0" column="9">
       <widget class="QPushButton" name="pushButtonAutoCrop">
        <property name="text">
         <string>Auto Crop</string>
@@ -171,7 +171,7 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="7">
+     <item row="0" column="8">
       <spacer name="horizontalSpacer_4">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -194,6 +194,16 @@
        </property>
        <property name="text">
         <string>&amp;Hide Rubber Band</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="7">
+      <widget class="QCheckBox" name="checkBoxKeepAspect">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="text">
+        <string>Keep aspect ratio</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Hi!

Added a "Keep aspect ratio" option to the Crop video filter.
When enabled, the aspect ratio of the source can be maintained on the selected crop area, if the rubber-band is dragged by the bottom-right corner. The top-left corner continue to be free dragging,the numeric inputs are unchanged.

(Use-case: recently i had to cut several scenes out of a video, and the areas of interest had different sizes and positions. )