### PR TITLE
MPlayer eq2 video filter luma histogram

### DIFF
--- a/avidemux_plugins/ADM_videoFilters6/eq2/qt4/DIA_flyEq2.h
+++ b/avidemux_plugins/ADM_videoFilters6/eq2/qt4/DIA_flyEq2.h
@@ -15,20 +15,23 @@
 #ifndef FLY_EQ2_H
 #define FLY_EQ2_H
 #include "ADM_vidEq2.h"
+class QGraphicsScene;
 class flyEq2 : public ADM_flyDialogYuv
 {
   
   public:
    eq2         param;
+   QGraphicsScene *scene;
+   bool        fullpreview;
   public:
    uint8_t    processYuv(ADMImage* in, ADMImage *out);
    uint8_t    download(void);
    uint8_t    upload(void);
    uint8_t    update(void);
-              flyEq2 (QDialog *parent, uint32_t width, uint32_t height, ADM_coreVideoFilter *in, ADM_QCanvas *canvas, ADM_QSlider *slider) :
+              flyEq2 (QDialog *parent, uint32_t width, uint32_t height, ADM_coreVideoFilter *in, ADM_QCanvas *canvas, ADM_QSlider *slider,QGraphicsScene*sc) :
                   ADM_flyDialogYuv(parent, width, height, in, canvas, slider, RESIZE_AUTO)
                     {
-                      
+                      scene=sc;
                     };
 };
 

--- a/avidemux_plugins/ADM_videoFilters6/eq2/qt4/Q_eq2.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/eq2/qt4/Q_eq2.cpp
@@ -38,13 +38,20 @@ Ui_eq2Window::Ui_eq2Window(QWidget *parent, eq2 *param,ADM_coreVideoFilter *in) 
 
     canvas=new ADM_QCanvas(ui.graphicsView,width,height);
 
-    myCrop=new flyEq2(this, width, height,in,canvas,ui.horizontalSlider);
+    scene=new QGraphicsScene(this);
+    ui.graphicsViewHistogram->setScene(scene);
+    ui.graphicsViewHistogram->scale(1.0,1.0);
+
+    myCrop=new flyEq2(this, width, height,in,canvas,ui.horizontalSlider,scene);
     memcpy(&(myCrop->param),param,sizeof(eq2));
     myCrop->_cookie=&ui;
+    myCrop->fullpreview = false;
     myCrop->addControl(ui.toolboxLayout);
     myCrop->upload();
     myCrop->sliderChanged();
     myCrop->update();
+
+    ui.checkBoxFullPreview->setChecked(myCrop->fullpreview);
 
     QSignalMapper *signalMapper = new QSignalMapper(this);
     connect( signalMapper,SIGNAL(mapped(QWidget*)),this,SLOT(resetSlider(QWidget*)));
@@ -66,6 +73,8 @@ Ui_eq2Window::Ui_eq2Window(QWidget *parent, eq2 *param,ADM_coreVideoFilter *in) 
     SPINNER(Red);
     SPINNER(Blue);
     SPINNER(Green);
+
+    connect( ui.checkBoxFullPreview,SIGNAL(stateChanged(int)),this,SLOT(toggleFullPreview(int)));
 
     setResetSliderEnabledState();
 
@@ -149,6 +158,20 @@ void Ui_eq2Window::setResetSliderEnabledState(void)
 }
 
 /**
+ * \fn toggleFullPreview
+ */
+void Ui_eq2Window::toggleFullPreview(int checkState)
+{
+    bool fullpreview=false;
+    if(checkState)
+    {
+        fullpreview=true;
+    }
+    myCrop->fullpreview=fullpreview;
+    myCrop->sameImage();
+}
+
+/**
     \fn dtor
 */
 Ui_eq2Window::~Ui_eq2Window()
@@ -157,6 +180,7 @@ Ui_eq2Window::~Ui_eq2Window()
     myCrop=NULL;
     if(canvas) delete canvas;
     canvas=NULL;
+    scene=NULL;
 }
 
 /**

--- a/avidemux_plugins/ADM_videoFilters6/eq2/qt4/Q_eq2.h
+++ b/avidemux_plugins/ADM_videoFilters6/eq2/qt4/Q_eq2.h
@@ -20,6 +20,7 @@
 
 #include "ADM_vidEq2.h"
 #include "DIA_flyEq2.h"
+#include "QGraphicsScene"
 /**
     \class Ui_eq2Window
 */
@@ -29,6 +30,7 @@ class Ui_eq2Window : public QDialog
 
 protected:
     int lock;
+    QGraphicsScene *scene;
 
 public:
     flyEq2 *myCrop;
@@ -45,6 +47,7 @@ private slots:
     void sliderUpdate(int foo);
     void valueChanged(int foo);
     void resetSlider(QWidget *control);
+    void toggleFullPreview(int checkState);
 
 private:
     void resizeEvent(QResizeEvent *event);

--- a/avidemux_plugins/ADM_videoFilters6/eq2/qt4/eq2.ui
+++ b/avidemux_plugins/ADM_videoFilters6/eq2/qt4/eq2.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>651</width>
-    <height>560</height>
+    <width>763</width>
+    <height>505</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -29,7 +29,7 @@
    <property name="spacing">
     <number>6</number>
    </property>
-   <item row="5" column="2">
+   <item row="6" column="2">
     <spacer>
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -55,7 +55,7 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0" colspan="3">
+   <item row="7" column="0" colspan="3">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -144,7 +144,7 @@
      </item>
     </layout>
    </item>
-   <item row="3" column="0" colspan="3">
+   <item row="4" column="0" colspan="3">
     <widget class="ADM_QSlider" name="horizontalSlider">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -255,11 +255,65 @@
      </item>
     </layout>
    </item>
-   <item row="4" column="0" colspan="3">
+   <item row="1" column="2">
+    <layout class="QGridLayout">
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <property name="spacing">
+      <number>6</number>
+     </property>
+     <item row="0" column="0">
+      <widget class="QGraphicsView" name="graphicsViewHistogram">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>256</width>
+         <height>128</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>256</width>
+         <height>256</height>
+        </size>
+       </property>
+       <property name="verticalScrollBarPolicy">
+        <enum>Qt::ScrollBarAlwaysOff</enum>
+       </property>
+       <property name="horizontalScrollBarPolicy">
+        <enum>Qt::ScrollBarAlwaysOff</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="5" column="0" colspan="3">
     <widget class="QGraphicsView" name="graphicsView"/>
    </item>
-   <item row="2" column="0" colspan="2">
+   <item row="3" column="0" colspan="3">
     <layout class="QHBoxLayout" name="toolboxLayout"/>
+   </item>
+   <item row="2" column="0">
+    <widget class="QCheckBox" name="checkBoxFullPreview">
+     <property name="text">
+      <string>Show full preview</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
Hi!

I took the luma histogram from the Contrast filter, and hacked into the MPlayer eq2 video filter.
Also added a "Show full preview" checkbox. When selected, the effects are shown on the full area of the preview, otherwise only on the right half (same as before this commit). 