### PR TITLE
MPlayer eq2 bugfix (filters for U-V was swapped)

### DIFF
--- a/avidemux_plugins/ADM_videoFilters6/eq2/ADM_vidEq2.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/eq2/ADM_vidEq2.cpp
@@ -146,15 +146,15 @@ void ADMVideoEq2::setCoupledConf(CONFcouple *couples)
   if(CpuCaps::hasMMX())
   {
         affine_1d_MMX(&(settings.param[0]),image,image,PLANAR_Y);
-        affine_1d_MMX(&(settings.param[2]),image,image,PLANAR_U);
-        affine_1d_MMX(&(settings.param[1]),image,image,PLANAR_V);
+        affine_1d_MMX(&(settings.param[1]),image,image,PLANAR_U);
+        affine_1d_MMX(&(settings.param[2]),image,image,PLANAR_V);
    }
    else
 #endif
    {
         apply_lut(&(settings.param[0]),image,image,PLANAR_Y);
-        apply_lut(&(settings.param[2]),image,image,PLANAR_U);
-        apply_lut(&(settings.param[1]),image,image,PLANAR_V);
+        apply_lut(&(settings.param[1]),image,image,PLANAR_U);
+        apply_lut(&(settings.param[2]),image,image,PLANAR_V);
     }
 
   return 1;

--- a/avidemux_plugins/ADM_videoFilters6/eq2/qt4/DIA_flyEq2.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/eq2/qt4/DIA_flyEq2.cpp
@@ -67,8 +67,8 @@ uint8_t    flyEq2::processYuv(ADMImage* in, ADMImage *out)
 	        }
 #endif	
 	        lutMe(&(mySettings.param[0]),in,out,PLANAR_Y);
-            lutMe(&(mySettings.param[2]),in,out,PLANAR_U);
-            lutMe(&(mySettings.param[1]),in,out,PLANAR_V);
+            lutMe(&(mySettings.param[1]),in,out,PLANAR_U);
+            lutMe(&(mySettings.param[2]),in,out,PLANAR_V);
 	        
 	        	
 


### PR DESCRIPTION
The red and blue gamma sliders operate as them being swapped. It was fine in 2.7.6.

> The meaning of PLANAR_U and PLANAR_V enumerators was unswapped recently in 3d57249 affecting all code matching anything to these enumerators.