### PR TITLE
ASharp valid range of spinboxes fixed, added sliders for convenience

### DIFF
--- a/avidemux_plugins/ADM_videoFilters6/asharp/qt4/Q_asharp.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/asharp/qt4/Q_asharp.cpp
@@ -20,6 +20,7 @@
 
 #include "Q_asharp.h"
 #include "ADM_toolkitQt.h"
+#include "math.h"
 
 //
 //	Video is in YV12 Colorspace
@@ -45,7 +46,9 @@
 
 
         connect( ui.horizontalSlider,SIGNAL(valueChanged(int)),this,SLOT(sliderUpdate(int)));
-#define SPINNER(x) connect( ui.doubleSpinBox##x,SIGNAL(valueChanged(double)),this,SLOT(valueChanged(double))); 
+#define SPINNER(x) connect( ui.doubleSpinBox##x,SIGNAL(valueChanged(double)),this,SLOT(valueChanged(double))); \
+		   connect( ui.horizontalSlider##x,SIGNAL(valueChanged(int)),this,SLOT(valueChangedSlider(int)));
+
           SPINNER(Treshold);
           SPINNER(Strength);
           SPINNER(Block);
@@ -102,6 +105,17 @@ void Ui_asharpWindow::showEvent(QShowEvent *event)
 }
 
 #define MYSPIN(x) w->doubleSpinBox##x
+#define MYSLIDER(x) w->horizontalSlider##x
+
+void Ui_asharpWindow::valueChangedSlider(int f)
+{
+	Ui_asharpDialog *w=(Ui_asharpDialog *)myCrop->_cookie;
+	MYSPIN(Treshold)->setValue((double)MYSLIDER(Treshold)->value() / 100.0);
+	MYSPIN(Strength)->setValue((double)MYSLIDER(Strength)->value() / 100.0);
+	MYSPIN(Block)->setValue((double)MYSLIDER(Block)->value() / 100.0);
+	valueChanged(0);
+}
+
 //************************
 uint8_t flyASharp::upload(void)
 {
@@ -110,6 +124,9 @@ uint8_t flyASharp::upload(void)
         MYSPIN(Treshold)->setValue(param.t);
         MYSPIN(Strength)->setValue(param.d);
         MYSPIN(Block)->setValue(param.b);
+	MYSLIDER(Treshold)->setValue(floor(param.t * 100.0));
+	MYSLIDER(Strength)->setValue(floor(param.d * 100.0));
+	MYSLIDER(Block)->setValue(floor(param.b * 100.0));
         
         //w->bf->w->checkBox->isChecked();
         w->checkBox->setChecked(param.bf);
@@ -122,7 +139,10 @@ uint8_t flyASharp::download(void)
        param.t= MYSPIN(Treshold)->value();
        param.d= MYSPIN(Strength)->value();
        param.b= MYSPIN(Block)->value();
-       
+	MYSLIDER(Treshold)->setValue(floor(MYSPIN(Treshold)->value() * 100.0));
+	MYSLIDER(Strength)->setValue(floor(MYSPIN(Strength)->value() * 100.0));
+	MYSLIDER(Block)->setValue(floor(MYSPIN(Block)->value() * 100.0));
+
        //w->spinBoxBottom->setValue(bottom);
        param.bf=w->checkBox->isChecked();
        return true;

--- a/avidemux_plugins/ADM_videoFilters6/asharp/qt4/Q_asharp.h
+++ b/avidemux_plugins/ADM_videoFilters6/asharp/qt4/Q_asharp.h
@@ -27,7 +27,8 @@ public slots:
 private slots:
 	void sliderUpdate(int foo);
 	void valueChanged(double foo);
-    void valueChanged2(int foo);
+	void valueChanged2(int foo);
+	void valueChangedSlider(int foo);
 
 private:
         void resizeEvent(QResizeEvent *event);

--- a/avidemux_plugins/ADM_videoFilters6/asharp/qt4/asharp.ui
+++ b/avidemux_plugins/ADM_videoFilters6/asharp/qt4/asharp.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>481</width>
-    <height>454</height>
+    <width>554</width>
+    <height>426</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -29,7 +29,20 @@
    <property name="spacing">
     <number>6</number>
    </property>
-   <item row="2" column="3">
+   <item row="2" column="5">
+    <spacer>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="5">
     <spacer>
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -43,42 +56,20 @@
     </spacer>
    </item>
    <item row="1" column="3">
-    <spacer>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="0" column="3">
-    <spacer>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="1" column="2">
-    <widget class="QDoubleSpinBox" name="doubleSpinBoxStrength"/>
-   </item>
-   <item row="3" column="0" colspan="3">
-    <widget class="QCheckBox" name="checkBox">
-     <property name="text">
-      <string>Unknown flag</string>
+    <widget class="QDoubleSpinBox" name="doubleSpinBoxStrength">
+     <property name="maximum">
+      <double>16.000000000000000</double>
      </property>
     </widget>
    </item>
-   <item row="3" column="3">
+   <item row="3" column="0" colspan="4">
+    <widget class="QCheckBox" name="checkBox">
+     <property name="text">
+      <string>High quality block filtering</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="5">
     <spacer>
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -91,21 +82,14 @@
      </property>
     </spacer>
    </item>
-   <item row="5" column="0" colspan="4">
+   <item row="5" column="0" colspan="6">
     <widget class="ADM_QSlider" name="horizontalSlider">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>
-   <item row="2" column="0" colspan="2">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>Block Adaptative</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="1" colspan="3">
+   <item row="7" column="1" colspan="5">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -115,8 +99,12 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="2">
-    <widget class="QDoubleSpinBox" name="doubleSpinBoxBlock"/>
+   <item row="2" column="3">
+    <widget class="QDoubleSpinBox" name="doubleSpinBoxBlock">
+     <property name="maximum">
+      <double>4.000000000000000</double>
+     </property>
+    </widget>
    </item>
    <item row="0" column="0">
     <widget class="QLabel" name="label">
@@ -125,21 +113,69 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0" colspan="4">
+   <item row="6" column="0" colspan="6">
     <widget class="QGraphicsView" name="graphicsView"/>
    </item>
-   <item row="0" column="2">
-    <widget class="QDoubleSpinBox" name="doubleSpinBoxTreshold"/>
+   <item row="0" column="3">
+    <widget class="QDoubleSpinBox" name="doubleSpinBoxTreshold">
+     <property name="maximum">
+      <double>32.000000000000000</double>
+     </property>
+    </widget>
    </item>
    <item row="1" column="0">
     <widget class="QLabel" name="label_2">
      <property name="text">
-      <string>Strength</string>
+      <string>Adaptive strength</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="4" column="0" colspan="6">
     <layout class="QHBoxLayout" name="toolboxLayout"/>
+   </item>
+   <item row="0" column="1">
+    <widget class="QSlider" name="horizontalSliderTreshold">
+     <property name="maximum">
+      <number>3200</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Block adaptive</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QSlider" name="horizontalSliderBlock">
+     <property name="maximum">
+      <number>400</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QSlider" name="horizontalSliderStrength">
+     <property name="maximum">
+      <number>1600</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="5">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>(0 == disabled)</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/avidemux_plugins/ADM_videoFilters6/asharp/qt4/asharp.ui
+++ b/avidemux_plugins/ADM_videoFilters6/asharp/qt4/asharp.ui
@@ -171,11 +171,17 @@
     </widget>
    </item>
    <item row="1" column="5">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>(0 == disabled)</string>
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
-    </widget>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
The ranges of the spinboxes were 0 .. 99
According to [http://avisynth.nl/index.php/ASharp]:
>Unsharp masking threshold range is from 0 to 32.
>Adaptive sharpening strength must be between 0 and 16.
>Block adaptive sharpening must be less than 4.
I double checked with the underlying code, i can confirm these ranges apply here too.

Added slider controls for the spinboxes for convenience (they are in sync with the spinboxes).

Changed "Unknown flag" to "High quality block filtering"