### PR TITLE
MSharpen bugfix and improvements

### DIFF
--- a/avidemux_plugins/ADM_videoFilters6/mSharpen/ADM_vidMSharpen.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/mSharpen/ADM_vidMSharpen.cpp
@@ -59,6 +59,7 @@ Msharpen::Msharpen(ADM_coreVideoFilter *in,CONFcouple *couples)
     {
         _param.mask=0;       // Show mask
         _param.highq=1;
+        _param.chroma=0;
         _param.strength=100;	
         _param.threshold=15;	
     }
@@ -96,9 +97,9 @@ Msharpen::~Msharpen(void)
 */
 const char *Msharpen::getConfiguration(void)
 {
-   static char conf[80];
+   static char conf[160];
     conf[0]=0;
-    snprintf(conf,80," Msharpen Strength:%d Threshold:%d",_param.strength,_param.threshold);
+    snprintf(conf,160," Msharpen Strength:%d Threshold:%d Process chroma:%s",_param.strength,_param.threshold,(_param.chroma ? "true":"false"));
     return conf;
 }
 	
@@ -118,7 +119,9 @@ ADMImage *src,*blur,*dst;
 
     dst->Pts=src->Pts;
 	
-    for (int i=0;i<3;i++)
+    invstrength=255-_param.strength;	// bugfix
+
+    for (int i=0;i<(_param.chroma ? 3:1);i++)
     {
             
             blur_plane(src, blur, i,work);
@@ -127,6 +130,11 @@ ADMImage *src,*blur,*dst;
                 detect_edges_HiQ(blur, dst,  i,_param);
             if (!_param.mask) 
                 apply_filter(src, blur, dst,  i,_param,invstrength);
+    }
+    if (!_param.chroma)
+    {
+        dst->copyPlane(src,dst,PLANAR_U);
+        dst->copyPlane(src,dst,PLANAR_V);
     }
 
     *fn=nextFrame;

--- a/avidemux_plugins/ADM_videoFilters6/mSharpen/msharpen.conf
+++ b/avidemux_plugins/ADM_videoFilters6/mSharpen/msharpen.conf
@@ -1,6 +1,7 @@
 msharpen{
 bool:mask 
 bool:highq 
+bool:chroma 
 uint32_t:threshold
 uint32_t:strength
 }

--- a/avidemux_plugins/ADM_videoFilters6/mSharpen/msharpen.h
+++ b/avidemux_plugins/ADM_videoFilters6/mSharpen/msharpen.h
@@ -4,6 +4,7 @@
 typedef struct {
 bool mask;
 bool highq;
+bool chroma;
 uint32_t threshold;
 uint32_t strength;
 }msharpen;

--- a/avidemux_plugins/ADM_videoFilters6/mSharpen/msharpen_desc.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/mSharpen/msharpen_desc.cpp
@@ -2,6 +2,7 @@
 extern const ADM_paramList msharpen_param[]={
  {"mask",offsetof(msharpen,mask),"bool",ADM_param_bool},
  {"highq",offsetof(msharpen,highq),"bool",ADM_param_bool},
+ {"chroma",offsetof(msharpen,chroma),"bool",ADM_param_bool},
  {"threshold",offsetof(msharpen,threshold),"uint32_t",ADM_param_uint32_t},
  {"strength",offsetof(msharpen,strength),"uint32_t",ADM_param_uint32_t},
 {NULL,0,NULL}

--- a/avidemux_plugins/ADM_videoFilters6/mSharpen/msharpen_json.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/mSharpen/msharpen_json.cpp
@@ -7,6 +7,7 @@ bool  msharpen_jserialize(const char *file, const msharpen *key){
 admJson json;
 json.addBool("mask",key->mask);
 json.addBool("highq",key->highq);
+json.addBool("chroma",key->chroma);
 json.addUint32("threshold",key->threshold);
 json.addUint32("strength",key->strength);
 return json.dumpToFile(file);

--- a/avidemux_plugins/ADM_videoFilters6/mSharpen/qt4/DIA_flymsharpen.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/mSharpen/qt4/DIA_flymsharpen.cpp
@@ -82,7 +82,7 @@ uint8_t    flyMSharpen::processYuv(ADMImage* in, ADMImage *out)
         refOut._planes[i]     =out->_planes[i]+halfWidth;
     }
     
-    for (int i=0;i<3;i++)
+    for (int i=0;i<(param.chroma ? 3:1);i++)
     { 
             Msharpen::blur_plane(&refIn, blur, i,work);
             Msharpen::detect_edges(blur, &refOut,  i,param);
@@ -90,6 +90,11 @@ uint8_t    flyMSharpen::processYuv(ADMImage* in, ADMImage *out)
                 Msharpen::detect_edges_HiQ(blur, &refOut,  i,param);
             if (!param.mask) 
                 Msharpen::apply_filter(&refIn, blur, &refOut,  i,param,invstrength);
+    }
+    if (!param.chroma)
+    {
+        (&refOut)->copyPlane(&refIn,&refOut,PLANAR_U);
+        (&refOut)->copyPlane(&refIn,&refOut,PLANAR_V);
     }
     out->copyInfo(in);
     out->printString(1,1,"Original"); // printString can't handle non-ascii input, do not translate this!
@@ -106,13 +111,17 @@ uint8_t flyMSharpen::upload()
 {
 #define MYSPIN(x) w->x
 #define MYTOGGLE(x) w->x
+#define MYSLIDER(x) w->horizontalSlider##x
     Ui_msharpenDialog *w=(Ui_msharpenDialog *)_cookie;
     
     
     MYSPIN(spinBoxThreshold)->setValue(param.threshold);
     MYSPIN(spinBoxStrength)->setValue(param.strength);
+    MYSLIDER(Threshold)->setValue(param.threshold);
+    MYSLIDER(Strength)->setValue(param.strength);
     MYTOGGLE(CheckBoxHQ)->setChecked(param.highq);
     MYTOGGLE(checkBoxMask)->setChecked(param.mask);
+    MYTOGGLE(checkBoxChroma)->setChecked(param.chroma);
     invstrength=255-param.strength;	
     printf("Upload\n");
     return 1;
@@ -125,13 +134,17 @@ uint8_t flyMSharpen::download(void)
     
 #define MYSPIN(x) w->x
 #define MYTOGGLE(x) w->x
+#define MYSLIDER(x) w->horizontalSlider##x
     Ui_msharpenDialog *w=(Ui_msharpenDialog *)_cookie;
     
     
     param.threshold=MYSPIN(spinBoxThreshold)->value();
     param.strength=MYSPIN(spinBoxStrength)->value();
+    MYSLIDER(Threshold)->setValue(param.threshold);
+    MYSLIDER(Strength)->setValue(param.strength);
     param.highq= MYTOGGLE(CheckBoxHQ)->isChecked();
     param.mask= MYTOGGLE(checkBoxMask)->isChecked();
+    param.chroma= MYTOGGLE(checkBoxChroma)->isChecked();
     invstrength=255-param.strength;	
     printf("Download\n");
     return true;

--- a/avidemux_plugins/ADM_videoFilters6/mSharpen/qt4/Q_msharpen.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/mSharpen/qt4/Q_msharpen.cpp
@@ -45,11 +45,13 @@
 
 
         connect( ui.horizontalSlider,SIGNAL(valueChanged(int)),this,SLOT(sliderUpdate(int)));
-#define SPINNER(x) connect( ui.spinBox##x,SIGNAL(valueChanged(int)),this,SLOT(valueChanged(int))); 
+#define SPINNER(x) connect( ui.spinBox##x,SIGNAL(valueChanged(int)),this,SLOT(valueChanged(int)));\
+		   connect( ui.horizontalSlider##x,SIGNAL(valueChanged(int)),this,SLOT(valueChangedSlider(int)));
 #define TOGGLER(x) connect( ui.x,SIGNAL(stateChanged(int)),this,SLOT(valueChanged(int))); 
         
         TOGGLER(CheckBoxHQ);
         TOGGLER(checkBoxMask);
+        TOGGLER(checkBoxChroma);
         
         SPINNER(Threshold);
         SPINNER(Strength);
@@ -100,8 +102,13 @@ void Ui_msharpenWindow::showEvent(QShowEvent *event)
     canvas->parentWidget()->setMinimumSize(30,30); // allow resizing after the dialog has settled
 }
 
-#define MYSPIN(x) w->doubleSpinBox##x
-
+#define SYNCSPIN(x) ui.spinBox##x->setValue(ui.horizontalSlider##x->value());
+void Ui_msharpenWindow::valueChangedSlider(int f)
+{
+	SYNCSPIN(Threshold);
+	SYNCSPIN(Strength);
+	valueChanged(0);
+}
 //____________________________________
 // EOF
 

--- a/avidemux_plugins/ADM_videoFilters6/mSharpen/qt4/Q_msharpen.h
+++ b/avidemux_plugins/ADM_videoFilters6/mSharpen/qt4/Q_msharpen.h
@@ -24,6 +24,7 @@ public slots:
 private slots:
         void sliderUpdate(int foo);
         void valueChanged(int foo);
+	void valueChangedSlider(int foo);
 
 private:
         void resizeEvent(QResizeEvent *event);

--- a/avidemux_plugins/ADM_videoFilters6/mSharpen/qt4/msharpen.ui
+++ b/avidemux_plugins/ADM_videoFilters6/mSharpen/qt4/msharpen.ui
@@ -125,9 +125,6 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
-    <layout class="QHBoxLayout" name="toolboxLayout"/>
-   </item>
    <item row="2" column="0">
     <widget class="QCheckBox" name="CheckBoxHQ">
      <property name="text">
@@ -138,7 +135,7 @@
    <item row="0" column="2">
     <widget class="QSpinBox" name="spinBoxStrength">
      <property name="minimum">
-      <number>1</number>
+      <number>0</number>
      </property>
      <property name="maximum">
       <number>255</number>
@@ -148,10 +145,40 @@
    <item row="1" column="2">
     <widget class="QSpinBox" name="spinBoxThreshold">
      <property name="minimum">
-      <number>1</number>
+      <number>0</number>
      </property>
      <property name="maximum">
       <number>255</number>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QSlider" name="horizontalSliderThreshold">
+     <property name="maximum">
+      <number>255</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QSlider" name="horizontalSliderStrength">
+     <property name="maximum">
+      <number>255</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="4">
+    <layout class="QHBoxLayout" name="toolboxLayout"/>
+   </item>
+   <item row="2" column="1">
+    <widget class="QCheckBox" name="checkBoxChroma">
+     <property name="text">
+      <string>Process chroma</string>
      </property>
     </widget>
    </item>
@@ -164,6 +191,17 @@
    <header>ADM_toolkitQt.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>horizontalSliderStrength</tabstop>
+  <tabstop>spinBoxStrength</tabstop>
+  <tabstop>horizontalSliderThreshold</tabstop>
+  <tabstop>spinBoxThreshold</tabstop>
+  <tabstop>CheckBoxHQ</tabstop>
+  <tabstop>checkBoxChroma</tabstop>
+  <tabstop>checkBoxMask</tabstop>
+  <tabstop>horizontalSlider</tabstop>
+  <tabstop>graphicsView</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>


### PR DESCRIPTION
Hi!

There was a bug in the filter, the "invstrength" variable should be binded to "_param.strength", but sometimes it has not been updated.
Added sliders for convenience (they are in sync with the spinboxes).
Also added a "Process chroma" option (intense sharpening can cause color artifacts, if applied on chroma).
I left the "HighQuality" string as is, to not break translations.
The UI tab order is set.