### PR TITLE
[security patch] use encrypted channel for update check

### DIFF
--- a/avidemux/qt4/ADM_update/private_inc/ADM_updateImpl.h
+++ b/avidemux/qt4/ADM_update/private_inc/ADM_updateImpl.h
@@ -22,7 +22,7 @@
 #if 0
 #define ADM_UPDATE_SERVER "http://192.168.0.9/"
 #else
-#define ADM_UPDATE_SERVER "http://www.avidemux.org/update/"
+#define ADM_UPDATE_SERVER "https://www.avidemux.org/update/"
 #endif
 
 // Helper defines to construct URL


### PR DESCRIPTION
Hi!

The current update check use plain http to get the update info, which can be easily hijacked.
Assuming a hijacked connection, the cases i tested:
1) someone can inject malicious URL, that will popup on startup (inattentive/inexperienced users can be deceived)
2) memory overflow, which can lead to unusable/crashed system (swapping, OOM killer, etc...)
For example i fabricated a file with size around 5 GiB. In a minute (i have fiber :) ) the memory usage of avidemux was over 5 GiB.

If the avidemux.org server has limited resources, you can use github as for example: 
https : // raw.githubusercontent.com/mean00/avidemux2/master/update/