### PR TITLE
[crop/qt5] spinbox bugfix

### DIFF
--- a/avidemux_plugins/ADM_videoFilters6/crop/qt5/DIA_flyCrop.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/crop/qt5/DIA_flyCrop.cpp
@@ -410,6 +410,10 @@ uint8_t flyCrop::upload(bool redraw, bool toRubber)
     w->spinBoxRight->setValue(right);
     w->spinBoxTop->setValue(top);
     w->spinBoxBottom->setValue(bottom);
+    w->spinBoxLeft->setMaximum(_w-right-2);
+    w->spinBoxRight->setMaximum(_w-left-2);
+    w->spinBoxTop->setMaximum(_h-bottom-2);
+    w->spinBoxBottom->setMaximum(_h-top-2);
     dimensions();
 
     if(toRubber)
@@ -485,6 +489,10 @@ Ui_cropDialog *w=(Ui_cropDialog *)_cookie;
                     bottom++;
             }
         }
+        w->spinBoxLeft->setMaximum(_w-right-2);
+        w->spinBoxRight->setMaximum(_w-left-2);
+        w->spinBoxTop->setMaximum(_h-bottom-2);
+        w->spinBoxBottom->setMaximum(_h-top-2);
         rubber->nestedIgnore++;
         rubber->move(_zoom*left+0.49,_zoom*top+0.49);
         rubber->resize(_zoom*bound(left,right,_w)+0.49,_zoom*bound(top,bottom,_h)+0.49);

--- a/avidemux_plugins/ADM_videoFilters6/crop/qt5/crop.ui
+++ b/avidemux_plugins/ADM_videoFilters6/crop/qt5/crop.ui
@@ -74,6 +74,9 @@
        <property name="maximum">
         <number>2147483647</number>
        </property>
+       <property name="singleStep">
+        <number>2</number>
+       </property>
       </widget>
      </item>
      <item row="1" column="0">
@@ -125,6 +128,9 @@
        <property name="maximum">
         <number>2147483647</number>
        </property>
+       <property name="singleStep">
+        <number>2</number>
+       </property>
       </widget>
      </item>
      <item row="0" column="9">
@@ -139,12 +145,18 @@
        <property name="maximum">
         <number>2147483647</number>
        </property>
+       <property name="singleStep">
+        <number>2</number>
+       </property>
       </widget>
      </item>
      <item row="1" column="1">
       <widget class="QSpinBox" name="spinBoxTop">
        <property name="maximum">
         <number>2147483647</number>
+       </property>
+       <property name="singleStep">
+        <number>2</number>
        </property>
       </widget>
      </item>

--- a/avidemux_plugins/ADM_videoFilters6/crop/qt5/crop.ui
+++ b/avidemux_plugins/ADM_videoFilters6/crop/qt5/crop.ui
@@ -71,6 +71,12 @@
      </item>
      <item row="0" column="4">
       <widget class="QSpinBox" name="spinBoxRight">
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximum">
         <number>2147483647</number>
        </property>
@@ -125,6 +131,12 @@
      </item>
      <item row="1" column="4">
       <widget class="QSpinBox" name="spinBoxBottom">
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximum">
         <number>2147483647</number>
        </property>
@@ -142,6 +154,12 @@
      </item>
      <item row="0" column="1">
       <widget class="QSpinBox" name="spinBoxLeft">
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximum">
         <number>2147483647</number>
        </property>
@@ -152,6 +170,12 @@
      </item>
      <item row="1" column="1">
       <widget class="QSpinBox" name="spinBoxTop">
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximum">
         <number>2147483647</number>
        </property>


### PR DESCRIPTION
- spinbox stepsize increased to 2 (because of YV12)
- on change set spinbox maximums, to prevent inversion (bad UX)
- these maximums prevent to set output resolution lower than 2x2 (if one of the dimension is 0, closing filter config will results Avidemux to crash)
- spinboxes get minimum width, to prevent jerkyness

