### PR TITLE
[crop/qt5] spinbox bugfix

### DIFF
--- a/avidemux_plugins/ADM_videoFilters6/crop/qt5/DIA_flyCrop.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/crop/qt5/DIA_flyCrop.cpp
@@ -485,6 +485,10 @@ Ui_cropDialog *w=(Ui_cropDialog *)_cookie;
                     bottom++;
             }
         }
+        w->spinBoxLeft->setMaximum(_w-right-8);
+        w->spinBoxRight->setMaximum(_w-left-8);
+        w->spinBoxTop->setMaximum(_h-bottom-8);
+        w->spinBoxBottom->setMaximum(_h-top-8);
         rubber->nestedIgnore++;
         rubber->move(_zoom*left+0.49,_zoom*top+0.49);
         rubber->resize(_zoom*bound(left,right,_w)+0.49,_zoom*bound(top,bottom,_h)+0.49);

--- a/avidemux_plugins/ADM_videoFilters6/crop/qt5/crop.ui
+++ b/avidemux_plugins/ADM_videoFilters6/crop/qt5/crop.ui
@@ -71,6 +71,12 @@
      </item>
      <item row="0" column="4">
       <widget class="QSpinBox" name="spinBoxRight">
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximum">
         <number>2147483647</number>
        </property>
@@ -122,6 +128,12 @@
      </item>
      <item row="1" column="4">
       <widget class="QSpinBox" name="spinBoxBottom">
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximum">
         <number>2147483647</number>
        </property>
@@ -136,6 +148,12 @@
      </item>
      <item row="0" column="1">
       <widget class="QSpinBox" name="spinBoxLeft">
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximum">
         <number>2147483647</number>
        </property>
@@ -143,6 +161,12 @@
      </item>
      <item row="1" column="1">
       <widget class="QSpinBox" name="spinBoxTop">
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximum">
         <number>2147483647</number>
        </property>


### PR DESCRIPTION
-on change set spinbox maximums, to prevent inversion (bad UX)
-these maximums prevent to set output resolution lower than 8x8
-spinboxes get minimum width, to prevent jerkiness (introduced by setMaximum)