### PR TITLE
[crop/qt5] Drag mode

### DIFF
--- a/avidemux_plugins/ADM_videoFilters6/crop/ADM_vidCrop.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/crop/ADM_vidCrop.cpp
@@ -74,6 +74,7 @@ CropFilter::CropFilter(ADM_coreVideoFilter *in,CONFcouple *couples) :ADM_coreVid
             configuration.left=0;
             configuration.right=0;
             configuration.rubber_is_hidden=false;
+            configuration.drag=false;
             configuration.keep_aspect=false;
             configuration.ar_select=0;
         }

--- a/avidemux_plugins/ADM_videoFilters6/crop/crop.conf
+++ b/avidemux_plugins/ADM_videoFilters6/crop/crop.conf
@@ -4,6 +4,7 @@ uint32_t:bottom
 uint32_t:left
 uint32_t:right
 bool:rubber_is_hidden
+bool:drag
 bool:keep_aspect
 uint32_t:ar_select
 }

--- a/avidemux_plugins/ADM_videoFilters6/crop/crop.h
+++ b/avidemux_plugins/ADM_videoFilters6/crop/crop.h
@@ -7,6 +7,7 @@ uint32_t bottom;
 uint32_t left;
 uint32_t right;
 bool rubber_is_hidden;
+bool drag;
 bool keep_aspect;
 uint32_t ar_select;
 }crop;

--- a/avidemux_plugins/ADM_videoFilters6/crop/crop_desc.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/crop/crop_desc.cpp
@@ -5,6 +5,7 @@ extern const ADM_paramList crop_param[]={
  {"left",offsetof(crop,left),"uint32_t",ADM_param_uint32_t},
  {"right",offsetof(crop,right),"uint32_t",ADM_param_uint32_t},
  {"rubber_is_hidden",offsetof(crop,rubber_is_hidden),"bool",ADM_param_bool},
+ {"drag",offsetof(crop,drag),"bool",ADM_param_bool},
  {"keep_aspect",offsetof(crop,keep_aspect),"bool",ADM_param_bool},
  {"ar_select",offsetof(crop,ar_select),"uint32_t",ADM_param_uint32_t},
 {NULL,0,NULL}

--- a/avidemux_plugins/ADM_videoFilters6/crop/qt5/DIA_flyCrop.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/crop/qt5/DIA_flyCrop.cpp
@@ -485,6 +485,10 @@ Ui_cropDialog *w=(Ui_cropDialog *)_cookie;
                     bottom++;
             }
         }
+        w->spinBoxLeft->setMaximum(_w-right-8);
+        w->spinBoxRight->setMaximum(_w-left-8);
+        w->spinBoxTop->setMaximum(_h-bottom-8);
+        w->spinBoxBottom->setMaximum(_h-top-8);
         rubber->nestedIgnore++;
         rubber->move(_zoom*left+0.49,_zoom*top+0.49);
         rubber->resize(_zoom*bound(left,right,_w)+0.49,_zoom*bound(top,bottom,_h)+0.49);

--- a/avidemux_plugins/ADM_videoFilters6/crop/qt5/DIA_flyCrop.h
+++ b/avidemux_plugins/ADM_videoFilters6/crop/qt5/DIA_flyCrop.h
@@ -9,6 +9,7 @@ class flyCrop : public ADM_flyDialogRgb
     int         _ox,_oy,_ow,_oh;
     uint32_t    left,right,top,bottom;
     bool        rubber_is_hidden;
+    bool        drag_enabled;
     bool        keep_aspect;
     int         ar_select;
     int         _lw,_lh;
@@ -31,9 +32,12 @@ public:
     double      getAspectRatio(void) {return ar;}
     int         getAspectRatioIndex(void) {return ar_select;}
     void        setAspectRatioIndex(int index);
+    bool        getDragEnabled(void) {return drag_enabled;}
+    void        setDragEnabled(bool drag) {drag_enabled=drag;}
     bool        getKeepAspect(void) {return keep_aspect;}
     void        setKeepAspect(bool keep) {keep_aspect=keep;}
     void        lockDimensions(void) {_lw=_w-left-right; _lh=_h-top-bottom;};
+    void        getDimensions(int * w, int * h) {if (w) *w=_lw; if(h) *h=_lh;};
 
     bool        getCropMargins(int *marginLeft, int *marginRight, int *marginTop, int *marginBottom);
     void        setCropMargins(int marginLeft, int marginRight, int marginTop, int marginBottom);

--- a/avidemux_plugins/ADM_videoFilters6/crop/qt5/Q_crop.h
+++ b/avidemux_plugins/ADM_videoFilters6/crop/qt5/Q_crop.h
@@ -25,6 +25,7 @@ private:
     ADM_QCanvas     *canvas;
     Ui_cropDialog   ui;
 
+    void updateLeftTopSpinners(int val, bool heightChanged);
     void updateRightBottomSpinners(int foo, bool useHeightAsRef);
     void resizeEvent(QResizeEvent *event);
     void showEvent(QShowEvent *event);
@@ -44,7 +45,7 @@ private slots:
     void autoCrop(bool f);
     void reset(bool f);
     void toggleRubber(int checkState);
-    void toggleKeepAspect(int checkState);
+    void changeRubberMode(int f);
     void changeARSelect(int f);
 };
 

--- a/avidemux_plugins/ADM_videoFilters6/crop/qt5/crop.ui
+++ b/avidemux_plugins/ADM_videoFilters6/crop/qt5/crop.ui
@@ -71,6 +71,12 @@
      </item>
      <item row="0" column="4">
       <widget class="QSpinBox" name="spinBoxRight">
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximum">
         <number>2147483647</number>
        </property>
@@ -122,6 +128,12 @@
      </item>
      <item row="1" column="4">
       <widget class="QSpinBox" name="spinBoxBottom">
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximum">
         <number>2147483647</number>
        </property>
@@ -136,6 +148,12 @@
      </item>
      <item row="0" column="1">
       <widget class="QSpinBox" name="spinBoxLeft">
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximum">
         <number>2147483647</number>
        </property>
@@ -143,6 +161,12 @@
      </item>
      <item row="1" column="1">
       <widget class="QSpinBox" name="spinBoxTop">
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="maximum">
         <number>2147483647</number>
        </property>

--- a/avidemux_plugins/ADM_videoFilters6/crop/qt5/crop.ui
+++ b/avidemux_plugins/ADM_videoFilters6/crop/qt5/crop.ui
@@ -221,16 +221,6 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="6">
-      <widget class="QCheckBox" name="checkBoxKeepAspect">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="text">
-        <string>Keep aspect ratio</string>
-       </property>
-      </widget>
-     </item>
      <item row="1" column="7">
       <widget class="QComboBox" name="comboBoxAspectRatio">
        <item>
@@ -271,6 +261,25 @@
        <item>
         <property name="text">
          <string>9:16</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="1" column="6">
+      <widget class="QComboBox" name="comboBoxRubberMode">
+       <item>
+        <property name="text">
+         <string>Free resize</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Free drag</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Keep aspect ratio</string>
         </property>
        </item>
       </widget>
@@ -316,7 +325,7 @@
   <tabstop>spinBoxBottom</tabstop>
   <tabstop>checkBoxRubber</tabstop>
   <tabstop>pushButtonAutoCrop</tabstop>
-  <tabstop>checkBoxKeepAspect</tabstop>
+  <tabstop>comboBoxRubberMode</tabstop>
   <tabstop>comboBoxAspectRatio</tabstop>
   <tabstop>pushButtonReset</tabstop>
   <tabstop>horizontalSlider</tabstop>


### PR DESCRIPTION
This feature branch is the continuation of 73b5bdd609af2b982c7de691a3f7037119a14d5e (pending Pull Request #212)

Actually editing video, i was still unsatisfied with the crop filter, because repositioning the selection was hard.
Therefore added a drag mode, by replacing "Keep aspect" chechbox with a comboBox, which has:
-Free resize (this is the original mode)
-Free drag
-Keep aspect ratio

However there is a bug i cant figure out (i suspect, it is in the underlying rubber mechanism):
start dragging, the drag point (top-left corner) can not be dragged beyond the pivot point, determined by the bottom-right corner when drag started. The visible rubber band resizes (moves) as it suppose to do, but it acts as if it were a secondary but invisible rubber band, that dont.
Releasing the drag grip, the dragging can be continued, with the new pivot point.