### PR TITLE
[videoFilters] Quick fixes

### DIFF
--- a/avidemux_plugins/ADM_videoFilters6/artCharcoal/qt4/DIA_flyArtCharcoal.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/artCharcoal/qt4/DIA_flyArtCharcoal.cpp
@@ -60,9 +60,7 @@ uint8_t   flyArtCharcoal::processYuv(ADMImage *in,ADMImage *out )
 {
     uint8_t *src,*dst;
     uint32_t stride;
-    out->copyPlane(in,out,PLANAR_Y);
-    out->copyPlane(in,out,PLANAR_U);
-    out->copyPlane(in,out,PLANAR_V);
+    out->duplicate(in);
 
     // Do it!
     ADMVideoArtCharcoal::ArtCharcoalProcess_C(out, work, param.scatterX, param.scatterY, param.intensity, param.color, param.invert);

--- a/avidemux_plugins/ADM_videoFilters6/artColorEffect/qt4/DIA_flyArtColorEffect.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/artColorEffect/qt4/DIA_flyArtColorEffect.cpp
@@ -41,9 +41,7 @@ uint8_t *src,*dst;
 uint32_t stride;
 uint32_t effect;
     effect=param.effect;
-    out->copyPlane(in,out,PLANAR_Y);
-    out->copyPlane(in,out,PLANAR_U);
-    out->copyPlane(in,out,PLANAR_V);
+    out->duplicate(in);
 
     // Do it!
     ArtColorEffectProcess_C(out,in->GetWidth(PLANAR_Y),in->GetHeight(PLANAR_Y),effect,rgbBufStride, rgbBufRaw, rgbBufImage, convertYuvToRgb, convertRgbToYuv);

--- a/avidemux_plugins/ADM_videoFilters6/artPixelize/qt4/DIA_flyArtPixelize.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/artPixelize/qt4/DIA_flyArtPixelize.cpp
@@ -40,9 +40,7 @@ uint8_t   flyArtPixelize::processYuv(ADMImage *in,ADMImage *out )
 {
     uint8_t *src,*dst;
     uint32_t stride;
-    out->copyPlane(in,out,PLANAR_Y);
-    out->copyPlane(in,out,PLANAR_U);
-    out->copyPlane(in,out,PLANAR_V);
+    out->duplicate(in);
 
     // Do it!
     ArtPixelizeProcess_C(out, param.pw, param.ph);

--- a/avidemux_plugins/ADM_videoFilters6/artVHS/qt4/DIA_flyArtVHS.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/artVHS/qt4/DIA_flyArtVHS.cpp
@@ -34,9 +34,7 @@ uint8_t   flyArtVHS::processYuv(ADMImage *in,ADMImage *out )
 {
     uint8_t *src,*dst;
     uint32_t stride;
-    out->copyPlane(in,out,PLANAR_Y);
-    out->copyPlane(in,out,PLANAR_U);
-    out->copyPlane(in,out,PLANAR_V);
+    out->duplicate(in);
 
     // Do it!
     ADMVideoArtVHS::ArtVHSProcess_C(out, param.lumaBW, param.chromaBW, param.unSync, param.unSyncFilter, param.lumaNoDelay, param.chromaNoDelay);

--- a/avidemux_plugins/ADM_videoFilters6/artVignette/qt4/DIA_flyArtVignette.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/artVignette/qt4/DIA_flyArtVignette.cpp
@@ -32,9 +32,7 @@ uint8_t   flyArtVignette::processYuv(ADMImage *in,ADMImage *out )
 {
     uint8_t *src,*dst;
     uint32_t stride;
-    out->copyPlane(in,out,PLANAR_Y);
-    out->copyPlane(in,out,PLANAR_U);
-    out->copyPlane(in,out,PLANAR_V);
+    out->duplicate(in);
 
     // Do it!
     ADMVideoArtVignette::ArtVignetteProcess_C(out, filterMask);

--- a/avidemux_plugins/ADM_videoFilters6/colorTemp/qt4/DIA_flyColorTemp.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/colorTemp/qt4/DIA_flyColorTemp.cpp
@@ -35,9 +35,7 @@ uint8_t   flyColorTemp::processYuv(ADMImage *in,ADMImage *out )
 {
     uint8_t *src,*dst;
     uint32_t stride;
-    out->copyPlane(in,out,PLANAR_Y);
-    out->copyPlane(in,out,PLANAR_U);
-    out->copyPlane(in,out,PLANAR_V);
+    out->duplicate(in);
 
     // Do it!
     ADMVideoColorTemp::ColorTempProcess_C(out, param.temperature, param.angle);

--- a/avidemux_plugins/ADM_videoFilters6/negative/ADM_negative.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/negative/ADM_negative.cpp
@@ -105,8 +105,8 @@ bool negativeFilter::getNextFrame(uint32_t *fn,ADMImage *image)
         return false;
     }
 
-    if(img->_range == ADM_COL_RANGE_MPEG)
-        img->expandColorRange();
+    if(image->_range == ADM_COL_RANGE_MPEG)
+        image->expandColorRange();
 
     if(config.invertY)
     {

--- a/avidemux_plugins/ADM_videoFilters6/negative/ADM_negative.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/negative/ADM_negative.cpp
@@ -104,6 +104,10 @@ bool negativeFilter::getNextFrame(uint32_t *fn,ADMImage *image)
         ADM_warning("Negative : Cannot get frame\n");
         return false;
     }
+
+    if(img->_range == ADM_COL_RANGE_MPEG)
+        img->expandColorRange();
+
     if(config.invertY)
     {
         invert_plane(image,PLANAR_Y);


### PR DESCRIPTION
[negative]: extend color range if the source is ADM_COL_RANGE_MPEG
Other filters: copy the whole image (incl. infos&flags!) to the output (instead just the planes) in the preview processor.