### PR TITLE
[ADM_coreVideoCodec] enable VP9 multithreading

### DIFF
--- a/avidemux_core/ADM_coreVideoCodec/include/ADM_codecFFsimple.h
+++ b/avidemux_core/ADM_coreVideoCodec/include/ADM_codecFFsimple.h
@@ -35,10 +35,11 @@ class decoderFFSimple:public decoderFF
 {
 protected:
     bool hasBFrame;
-
+    AVCodec * codec;
 public:
                 decoderFFSimple (uint32_t w, uint32_t h,uint32_t fcc, uint32_t extraDataLen, uint8_t *extraData,uint32_t bpp);
   virtual bool  bFramePossible (void)        {return hasBFrame; }
+           void finish(void);
   
 };
 

--- a/avidemux_core/ADM_coreVideoCodec/src/ADM_codecFFsimple.cpp
+++ b/avidemux_core/ADM_coreVideoCodec/src/ADM_codecFFsimple.cpp
@@ -33,7 +33,7 @@ decoderFFSimple::decoderFFSimple (uint32_t w, uint32_t h,uint32_t fcc, uint32_t 
         return;
 
     AVCodecID id=c->codecId;
-    AVCodec *codec=avcodec_find_decoder(id);
+    codec=avcodec_find_decoder(id);
     if(!codec)
     {
         GUI_Error_HIG(QT_TRANSLATE_NOOP("adm","Codec"),QT_TRANSLATE_NOOP("adm","Internal error finding codec 0x%x"),fcc);
@@ -57,15 +57,6 @@ decoderFFSimple::decoderFFSimple (uint32_t w, uint32_t h,uint32_t fcc, uint32_t 
     if(true==c->hasBFrame)
         hasBFrame=true;
 
-    decoderMultiThread();
-    if (_usingMT) {
-        if(codecId==AV_CODEC_ID_VP9) { //TODO investigate what other codecs can be multithreaded!
-            _context->thread_count = _threads;
-            _context->thread_type = FF_THREAD_SLICE;    // this is important! the default FF_THREAD_FRAME wont work with Avidemux
-        }
-    }
-    printf("[decoderFFSimple] context allocated with thread_count = %d\n",_context->thread_count);
-
     _context->width = _w;
     _context->height = _h;
     _context->pix_fmt = AV_PIX_FMT_YUV420P;
@@ -81,14 +72,20 @@ decoderFFSimple::decoderFFSimple (uint32_t w, uint32_t h,uint32_t fcc, uint32_t 
      _context->get_format=ADM_FFgetFormat; 
      _context->opaque=this;
     //
+}
+/**
+    \fn finish
+*/
+void decoderFFSimple::finish(void)
+{
     if (avcodec_open2(_context, codec, NULL) < 0)
     {
-        printf("[lavc] Decoder init: %x video decoder failed!\n",fcc);
-        GUI_Error_HIG(QT_TRANSLATE_NOOP("adm","Codec"),QT_TRANSLATE_NOOP("adm","Internal error opening 0x%x"),fcc);
+        printf("[lavc] Decoder init: %x video decoder failed!\n",_fcc);
+        GUI_Error_HIG(QT_TRANSLATE_NOOP("adm","Codec"),QT_TRANSLATE_NOOP("adm","Internal error opening 0x%x"),_fcc);
         return;
     }else
     {
-        printf("[lavc] Decoder init: %x video decoder initialized! (%s)\n",fcc,codec->long_name);
+        printf("[lavc] Decoder init: %x video decoder initialized with %d thread(s)! (%s)\n",_fcc,_context->thread_count,codec->long_name);
     }
     _initCompleted=true;
 }
@@ -102,6 +99,7 @@ decoders *admCreateFFSimple(uint32_t w, uint32_t h,uint32_t fcc, uint32_t extraD
     AVCodecID id=c->codecId;
     if(id==AV_CODEC_ID_NONE) return NULL;
     decoderFFSimple *ffdec=new decoderFFSimple(w,h,fcc,extraDataLen,extraData,bpp);
+    ffdec->finish();
     if(ffdec->initialized())
         return (decoders *)ffdec;
     delete ffdec;

--- a/avidemux_core/ADM_coreVideoCodec/src/ADM_codecFFsimple.cpp
+++ b/avidemux_core/ADM_coreVideoCodec/src/ADM_codecFFsimple.cpp
@@ -56,8 +56,15 @@ decoderFFSimple::decoderFFSimple (uint32_t w, uint32_t h,uint32_t fcc, uint32_t 
         _refCopy=1;
     if(true==c->hasBFrame)
         hasBFrame=true;
-    printf("[decoderFFSimple] context allocated with thread_count = %d\n",_context->thread_count);
+
     decoderMultiThread();
+    if (_usingMT) {
+        if(codecId==AV_CODEC_ID_VP9) { //TODO investigate what other codecs can be multithreaded!
+            _context->thread_count = _threads;
+            _context->thread_type = FF_THREAD_SLICE;    // this is important! the default FF_THREAD_FRAME wont work with Avidemux
+        }
+    }
+    printf("[decoderFFSimple] context allocated with thread_count = %d\n",_context->thread_count);
 
     _context->width = _w;
     _context->height = _h;

--- a/avidemux_core/ADM_coreVideoCodec/src/ADM_ffVp9.cpp
+++ b/avidemux_core/ADM_coreVideoCodec/src/ADM_ffVp9.cpp
@@ -29,6 +29,15 @@
 decoderFFVP9::decoderFFVP9 (uint32_t w, uint32_t h,uint32_t fcc, uint32_t extraDataLen, uint8_t *extraData,uint32_t bpp)
     : decoderFFSimple(w,h,fcc,extraDataLen,extraData,bpp)
 {
+
+    decoderMultiThread();
+    if (_usingMT) {
+        _context->thread_count = _threads;
+        _context->thread_type = FF_THREAD_SLICE;    // this is important! the default FF_THREAD_FRAME wont work with Avidemux
+    }
+
+    this->finish();
+
     _parserContext=NULL;
     if(!_initCompleted)
         return;


### PR DESCRIPTION
Experimental!
The _ADM_ffmp43_ multihreading does not cover VP9 encoded videos.
I can play now 4k60fps VP9 videos buttery smooth with this patch. With single thread it was p.i.t.a.
As far as i know _ADM_codecFFsimple_ / class _decoderFFSimple_ is not used elsewhere, but _ADM_codecFFVP9_  (is this true?).
Im not sure this is the correct way, to enable MT for VP9, but works for now..