### PR TITLE
[Q_mainfilter] fix crash

### DIFF
--- a/avidemux/qt4/ADM_userInterfaces/ADM_filters/Q_mainfilter.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_filters/Q_mainfilter.cpp
@@ -288,7 +288,11 @@ void filtermainWindow::preview(bool b)
 void filtermainWindow::closePreview()
 {
     if (previewDialog)
+    {
         qtUnregisterDialog(previewDialog);
+        delete previewDialog;
+        previewDialog = NULL;
+    }
 }
 
 /**


### PR DESCRIPTION
Closing the video filter manager's preview, the flydialog was not deleted, and that can caused crashes.
Video filter preview crash can be replicated:
    - instantiate any two filter, that has previews in the configuration dialog
    - open the global preview in the video filter manager, click play, then close with OK button
    - open the first filter, and click play, then close with OK button

Crash Dump for Crash
Segfault
 at line 0, file ??
ADM_backTrack

ADM_flyDialog::nextImageInternal()
ADM_flyDialog::nextImage()
ADM_flyDialog::timeout()
QMetaObject::activate(QObject*, int, int, void**)
QTimer::timeout(QTimer::QPrivateSignal)
QTimer::timerEvent(QTimerEvent*)
QObject::event(QEvent*)
QApplicationPrivate::notify_helper(QObject*, QEvent*)
QApplication::notify(QObject*, QEvent*)
QCoreApplication::notifyInternal2(QObject*, QEvent*)
QTimerInfoList::activateTimers()


