### PR TITLE
Flydialog Peek Original button + applied to filters

### DIFF
--- a/avidemux/qt4/ADM_UIs/include/DIA_flyDialogQt4.h
+++ b/avidemux/qt4/ADM_UIs/include/DIA_flyDialogQt4.h
@@ -98,6 +98,7 @@ class ADM_UIQT46_EXPORT ADM_flyDialog : public QObject
           flyControl  *_control;
           std::vector<QWidget *> buttonList; // useful for manipulating tab order
           QDialog     *_parent;
+          bool         _bypassFilter;
 
 
 
@@ -116,7 +117,7 @@ class ADM_UIQT46_EXPORT ADM_flyDialog : public QObject
           virtual bool       sameImage(void);
                   uint64_t   getCurrentPts();
           ADM_coreVideoFilter *getUnderlyingFilter() {return _in;}
-                  bool        addControl(QHBoxLayout *layout);
+                  bool        addControl(QHBoxLayout *layout, bool addPeekOriginalButton = false);
 protected:
   virtual ADM_colorspace     toRgbColor(void);
           void               updateZoom(void);
@@ -161,6 +162,8 @@ public slots:
         virtual void backOneMinute(void);
         virtual void fwdOneMinute(void);
         virtual void play(bool status);
+        virtual void peekOriginalPressed(void);
+        virtual void peekOriginalReleased(void);
         virtual void timeout(void);
         virtual void adjustCanvasPosition(void);
         virtual void fitCanvasIntoView(uint32_t width, uint32_t height);

--- a/avidemux_plugins/ADM_videoFilters6/artCartoon/qt4/Q_artCartoon.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/artCartoon/qt4/Q_artCartoon.cpp
@@ -44,7 +44,7 @@ Ui_artCartoonWindow::Ui_artCartoonWindow(QWidget *parent, artCartoon *param,ADM_
         ADMVideoArtCartoon::ArtCartoonCreateBuffers(width,height, &(myFly->rgbBufStride), &(myFly->rgbBufRaw), &(myFly->rgbBufImage), &(myFly->convertYuvToRgb), &(myFly->convertRgbToYuv));
         memcpy(&(myFly->param),param,sizeof(artCartoon));
         myFly->_cookie=&ui;
-        myFly->addControl(ui.toolboxLayout);
+        myFly->addControl(ui.toolboxLayout, true);
         myFly->upload();
         myFly->sliderChanged();
 

--- a/avidemux_plugins/ADM_videoFilters6/artCharcoal/qt4/Q_artCharcoal.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/artCharcoal/qt4/Q_artCharcoal.cpp
@@ -44,7 +44,7 @@ Ui_artCharcoalWindow::Ui_artCharcoalWindow(QWidget *parent, artCharcoal *param,A
         myFly=new flyArtCharcoal( this,width, height,in,canvas,ui.horizontalSlider);
         memcpy(&(myFly->param),param,sizeof(artCharcoal));
         myFly->_cookie=&ui;
-        myFly->addControl(ui.toolboxLayout);
+        myFly->addControl(ui.toolboxLayout, true);
         myFly->setTabOrder();
         myFly->upload();
         myFly->sliderChanged();

--- a/avidemux_plugins/ADM_videoFilters6/artChromaHold/qt4/Q_artChromaHold.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/artChromaHold/qt4/Q_artChromaHold.cpp
@@ -50,7 +50,7 @@ Ui_artChromaHoldWindow::Ui_artChromaHoldWindow(QWidget *parent, artChromaHold *p
         myFly=new flyArtChromaHold( this,width, height,in,canvas,ui.horizontalSlider, scene);
         memcpy(&(myFly->param),param,sizeof(artChromaHold));
         myFly->_cookie=&ui;
-        myFly->addControl(ui.toolboxLayout);
+        myFly->addControl(ui.toolboxLayout, true);
         myFly->upload();
         myFly->sliderChanged();
 

--- a/avidemux_plugins/ADM_videoFilters6/artChromaKey/qt4/Q_artChromaKey.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/artChromaKey/qt4/Q_artChromaKey.cpp
@@ -78,7 +78,7 @@ Ui_artChromaKeyWindow::Ui_artChromaKeyWindow(QWidget *parent, artChromaKey *para
 
         myFly->showTestImage = false;
         myFly->_cookie=&ui;
-        myFly->addControl(ui.toolboxLayout);
+        myFly->addControl(ui.toolboxLayout, true);
         myFly->upload();
         myFly->sliderChanged();
         myFly->sameImage();

--- a/avidemux_plugins/ADM_videoFilters6/artColorEffect/qt4/Q_artColorEffect.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/artColorEffect/qt4/Q_artColorEffect.cpp
@@ -41,7 +41,7 @@ Ui_artColorEffectWindow::Ui_artColorEffectWindow(QWidget *parent, artColorEffect
         myFly=new flyArtColorEffect( this,width, height,in,canvas,ui.horizontalSlider);
         memcpy(&(myFly->param),param,sizeof(artColorEffect));
         myFly->_cookie=&ui;
-        myFly->addControl(ui.toolboxLayout);
+        myFly->addControl(ui.toolboxLayout, true);
         myFly->setTabOrder();
         myFly->upload();
         myFly->sliderChanged();

--- a/avidemux_plugins/ADM_videoFilters6/artDynThreshold/qt4/Q_artDynThreshold.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/artDynThreshold/qt4/Q_artDynThreshold.cpp
@@ -44,7 +44,7 @@ Ui_artDynThresholdWindow::Ui_artDynThresholdWindow(QWidget *parent, artDynThresh
         myFly=new flyArtDynThreshold( this,width, height,in,canvas,ui.horizontalSlider);
         memcpy(&(myFly->param),param,sizeof(artDynThreshold));
         myFly->_cookie=&ui;
-        myFly->addControl(ui.toolboxLayout);
+        myFly->addControl(ui.toolboxLayout, true);
         myFly->setTabOrder();
         myFly->upload();
         myFly->sliderChanged();

--- a/avidemux_plugins/ADM_videoFilters6/artPixelize/qt4/Q_artPixelize.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/artPixelize/qt4/Q_artPixelize.cpp
@@ -41,7 +41,7 @@ Ui_artPixelizeWindow::Ui_artPixelizeWindow(QWidget *parent, artPixelize *param,A
         myFly=new flyArtPixelize( this,width, height,in,canvas,ui.horizontalSlider);
         memcpy(&(myFly->param),param,sizeof(artPixelize));
         myFly->_cookie=&ui;
-        myFly->addControl(ui.toolboxLayout);
+        myFly->addControl(ui.toolboxLayout, true);
         myFly->setTabOrder();
         myFly->upload();
         myFly->sliderChanged();

--- a/avidemux_plugins/ADM_videoFilters6/artPosterize/qt4/Q_artPosterize.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/artPosterize/qt4/Q_artPosterize.cpp
@@ -43,7 +43,7 @@ Ui_artPosterizeWindow::Ui_artPosterizeWindow(QWidget *parent, artPosterize *para
         ADMVideoArtPosterize::ArtPosterizeCreateBuffers(width,height, &(myFly->rgbBufStride), &(myFly->rgbBufRaw), &(myFly->rgbBufImage), &(myFly->convertYuvToRgb), &(myFly->convertRgbToYuv));
         memcpy(&(myFly->param),param,sizeof(artPosterize));
         myFly->_cookie=&ui;
-        myFly->addControl(ui.toolboxLayout);
+        myFly->addControl(ui.toolboxLayout, true);
         myFly->upload();
         myFly->sliderChanged();
 

--- a/avidemux_plugins/ADM_videoFilters6/artVHS/qt4/Q_artVHS.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/artVHS/qt4/Q_artVHS.cpp
@@ -44,7 +44,7 @@ Ui_artVHSWindow::Ui_artVHSWindow(QWidget *parent, artVHS *param,ADM_coreVideoFil
         myFly=new flyArtVHS( this,width, height,in,canvas,ui.horizontalSlider);
         memcpy(&(myFly->param),param,sizeof(artVHS));
         myFly->_cookie=&ui;
-        myFly->addControl(ui.toolboxLayout);
+        myFly->addControl(ui.toolboxLayout, true);
         myFly->setTabOrder();
         myFly->upload();
         myFly->sliderChanged();

--- a/avidemux_plugins/ADM_videoFilters6/artVignette/qt4/Q_artVignette.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/artVignette/qt4/Q_artVignette.cpp
@@ -47,7 +47,7 @@ Ui_artVignetteWindow::Ui_artVignetteWindow(QWidget *parent, artVignette *param,A
         myFly->filterH = height;
         myFly->filterMask = new float[width*height];
         myFly->_cookie=&ui;
-        myFly->addControl(ui.toolboxLayout);
+        myFly->addControl(ui.toolboxLayout, true);
         myFly->setTabOrder();
         myFly->upload();
         myFly->sliderChanged();

--- a/avidemux_plugins/ADM_videoFilters6/asharp/qt4/DIA_flyAsharp.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/asharp/qt4/DIA_flyAsharp.cpp
@@ -83,29 +83,7 @@ uint32_t ww,hh;
                         B2,
                         param.bf,line);
                 delete [] line;
-    if(fullpreview)
-        return 1;
-    // Copy back half source to display
-    dst=out->GetWritePtr(PLANAR_Y);
-    src=in->GetReadPtr(PLANAR_Y);
-    sstride=in->GetPitch(PLANAR_Y);
-    dstride=out->GetPitch(PLANAR_Y);
-    for(uint32_t y=0;y<hh;y++)   // We do both u & v!
-    {
-        memcpy(dst,src,ww/2);
-        dst+=dstride;
-        src+=sstride;
-    }
-    // add separator
-    dst=out->GetWritePtr(PLANAR_Y)+ww/2;
-    for(int j=0;j<hh/2;j++)
-    {
-        dst[0]=0;
-        dst[dstride]=0xff;
-        dst+=dstride*2;
-    }
-    out->printString(1,1,"Original"); // printString can't handle non-ascii input, do not translate this!
-    out->printString(ww/24+1,1,"Processed"); // as above, don't try to translate
+
     return 1;
 }
 //EOF

--- a/avidemux_plugins/ADM_videoFilters6/asharp/qt4/DIA_flyAsharp.h
+++ b/avidemux_plugins/ADM_videoFilters6/asharp/qt4/DIA_flyAsharp.h
@@ -9,7 +9,6 @@ class flyASharp : public ADM_flyDialogYuv
   
   public:
    asharp     param;
-   bool       fullpreview;
   public:
     uint8_t    processYuv(ADMImage* in, ADMImage *out);
     void       blockChanges(bool block);
@@ -20,6 +19,6 @@ class flyASharp : public ADM_flyDialogYuv
    uint8_t    update(void);
                 flyASharp (QDialog *parent,uint32_t width,uint32_t height,ADM_coreVideoFilter *in,
                                     ADM_QCanvas *canvas, ADM_QSlider *slider) :
-                    ADM_flyDialogYuv(parent,width, height,in,canvas, slider,RESIZE_AUTO) { fullpreview = false; }
+                    ADM_flyDialogYuv(parent,width, height,in,canvas, slider,RESIZE_AUTO) { }
 };
 

--- a/avidemux_plugins/ADM_videoFilters6/asharp/qt4/Q_asharp.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/asharp/qt4/Q_asharp.cpp
@@ -42,13 +42,12 @@ Ui_asharpWindow::Ui_asharpWindow(QWidget *parent, asharp *param, ADM_coreVideoFi
 
     memcpy(&(myCrop->param),param,sizeof(asharp));
     myCrop->_cookie=&ui;
-    myCrop->addControl(ui.toolboxLayout);
+    myCrop->addControl(ui.toolboxLayout, true);
     myCrop->setTabOrder();
     myCrop->upload();
     myCrop->sliderChanged();
 
     connect(ui.horizontalSlider,SIGNAL(valueChanged(int)),this,SLOT(sliderUpdate(int)));
-    connect(ui.checkBoxFullPreview,SIGNAL(stateChanged(int)),this,SLOT(toggleFullPreview(int)));
 #define SPINNER(x) connect( ui.doubleSpinBox##x,SIGNAL(valueChanged(double)),this,SLOT(valueChanged(double))); \
                    connect( ui.horizontalSlider##x,SIGNAL(valueChanged(int)),this,SLOT(valueChangedSlider(int)));
     SPINNER(Threshold)
@@ -90,14 +89,6 @@ void Ui_asharpWindow::valueChanged( double f )
     if(lock) return;
     lock++;
     myCrop->download();
-    myCrop->sameImage();
-    lock--;
-}
-void Ui_asharpWindow::toggleFullPreview(int state)
-{
-    if(lock) return;
-    lock++;
-    myCrop->fullpreview = state != Qt::Unchecked;
     myCrop->sameImage();
     lock--;
 }
@@ -218,7 +209,6 @@ void flyASharp::setTabOrder(void)
     controls.push_back(MYSLIDER(Block));
     controls.push_back(MYSPIN(Block));
     controls.push_back(MYCHKBOX(HQBF));
-    controls.push_back(MYCHKBOX(FullPreview));
 
     controls.insert(controls.end(), buttonList.begin(), buttonList.end());
     controls.push_back(w->horizontalSlider);

--- a/avidemux_plugins/ADM_videoFilters6/asharp/qt4/Q_asharp.h
+++ b/avidemux_plugins/ADM_videoFilters6/asharp/qt4/Q_asharp.h
@@ -26,7 +26,6 @@ private slots:
     void valueChanged(double foo);
     void valueChanged2(int foo);
     void valueChangedSlider(int foo);
-    void toggleFullPreview(int foo);
     void reset(void);
 
 private:

--- a/avidemux_plugins/ADM_videoFilters6/asharp/qt4/asharp.ui
+++ b/avidemux_plugins/ADM_videoFilters6/asharp/qt4/asharp.ui
@@ -143,13 +143,6 @@
       </widget>
      </item>
      <item>
-      <widget class="QCheckBox" name="checkBoxFullPreview">
-       <property name="text">
-        <string>Show full preview</string>
-       </property>
-      </widget>
-     </item>
-     <item>
       <spacer name="fullPreviewSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>

--- a/avidemux_plugins/ADM_videoFilters6/blur/qt4/Q_blur.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/blur/qt4/Q_blur.cpp
@@ -43,7 +43,7 @@ Ui_blurWindow::Ui_blurWindow(QWidget *parent, blur *param,ADM_coreVideoFilter *i
         ADMVideoBlur::BlurCreateBuffers(width,height, &(myFly->rgbBufStride), &(myFly->rgbBufRaw), &(myFly->rgbBufImage), &(myFly->convertYuvToRgb), &(myFly->convertRgbToYuv));
         memcpy(&(myFly->param),param,sizeof(blur));
         myFly->_cookie=&ui;
-        myFly->addControl(ui.toolboxLayout);
+        myFly->addControl(ui.toolboxLayout, true);
         myFly->upload();
         myFly->sliderChanged();
 

--- a/avidemux_plugins/ADM_videoFilters6/chromaShift/qt4/Q_chromashift.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/chromaShift/qt4/Q_chromashift.cpp
@@ -44,7 +44,7 @@ Ui_chromaShiftWindow::Ui_chromaShiftWindow(QWidget* parent, chromashift *param,A
         myCrop=new flyChromaShift( this,width, height,in,canvas,ui.horizontalSlider);
         memcpy(&(myCrop->param),param,sizeof(chromashift));
         myCrop->_cookie=&ui;
-        myCrop->addControl(ui.toolboxLayout);
+        myCrop->addControl(ui.toolboxLayout, true);
         myCrop->setTabOrder();
         myCrop->upload();
         myCrop->sliderChanged();

--- a/avidemux_plugins/ADM_videoFilters6/colorTemp/qt4/Q_colorTemp.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/colorTemp/qt4/Q_colorTemp.cpp
@@ -44,7 +44,7 @@ Ui_colorTempWindow::Ui_colorTempWindow(QWidget *parent, colorTemp *param,ADM_cor
         myFly=new flyColorTemp( this,width, height,in,canvas,ui.horizontalSlider);
         memcpy(&(myFly->param),param,sizeof(colorTemp));
         myFly->_cookie=&ui;
-        myFly->addControl(ui.toolboxLayout);
+        myFly->addControl(ui.toolboxLayout, true);
         myFly->setTabOrder();
         myFly->upload();
         myFly->sliderChanged();

--- a/avidemux_plugins/ADM_videoFilters6/contrast/qt4/DIA_flyContrast.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/contrast/qt4/DIA_flyContrast.cpp
@@ -30,7 +30,6 @@ flyContrast::flyContrast(QDialog *parent, uint32_t width, uint32_t height, ADM_c
     : ADM_flyDialogYuv(parent, width, height, in, canvas, slider, RESIZE_AUTO)
 {
     scene = sc;
-    previewActivated = true;
     tablesPopulated = false;
     oldCoef = 1.;
     oldOffset = 0;
@@ -51,29 +50,23 @@ uint8_t    flyContrast::processYuv(ADMImage* in, ADMImage *out)
         tablesPopulated = true;
     }
 
-    if(!previewActivated)
-    {
-        out->duplicate(in);
-    }
+    out->copyInfo(in);
+    if(param.doLuma)
+        ADMVideoContrast::doContrast(in,out,tableluma,PLANAR_Y);
     else
-    {
-        out->copyInfo(in);
-        if(param.doLuma)
-            ADMVideoContrast::doContrast(in,out,tableluma,PLANAR_Y);
-        else
-            out->copyPlane(in,out,PLANAR_Y);
+        out->copyPlane(in,out,PLANAR_Y);
 
 
-        if(param.doChromaU)
-            ADMVideoContrast::doContrast(in,out,tablechroma,PLANAR_U);
-        else
-            out->copyPlane(in,out,PLANAR_U);
+    if(param.doChromaU)
+        ADMVideoContrast::doContrast(in,out,tablechroma,PLANAR_U);
+    else
+        out->copyPlane(in,out,PLANAR_U);
 
-        if(param.doChromaV)
-            ADMVideoContrast::doContrast(in,out,tablechroma,PLANAR_V);
-        else
-            out->copyPlane(in,out,PLANAR_V);
-    }
+    if(param.doChromaV)
+        ADMVideoContrast::doContrast(in,out,tablechroma,PLANAR_V);
+    else
+        out->copyPlane(in,out,PLANAR_V);
+
     if(!scene) return true;
     
     // Draw luma histogram

--- a/avidemux_plugins/ADM_videoFilters6/contrast/qt4/DIA_flyContrast.h
+++ b/avidemux_plugins/ADM_videoFilters6/contrast/qt4/DIA_flyContrast.h
@@ -33,10 +33,8 @@ class flyContrast : public ADM_flyDialogYuv
   public:
     contrast    param;
     QGraphicsScene *scene;
-    bool        previewActivated;
   public:
     uint8_t     processYuv(ADMImage* in, ADMImage *out);
-    void        setState(bool a){previewActivated=a;}
     void        setTabOrder(void);
     uint8_t     download(void);
     uint8_t     upload(void);

--- a/avidemux_plugins/ADM_videoFilters6/contrast/qt4/Q_contrast.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/contrast/qt4/Q_contrast.cpp
@@ -46,14 +46,10 @@
         myCrop=new flyContrast( this,width, height,in,canvas,ui.horizontalSlider,scene);
         memcpy(&(myCrop->param),param,sizeof(contrast));
         myCrop->_cookie=&ui;
-        myCrop->addControl(ui.toolboxLayout);
+        myCrop->addControl(ui.toolboxLayout, true);
         myCrop->setTabOrder();
         myCrop->upload();
         myCrop->sliderChanged();
-
-        previewState=true;
-        ui.checkBox_Enabled->setChecked(true);
-
 
         connect( ui.horizontalSlider,SIGNAL(valueChanged(int)),this,SLOT(sliderUpdate(int)));
 #define SPINNER(x) connect( ui.dial##x,SIGNAL(valueChanged(int)),this,SLOT(valueChanged(int))); 
@@ -75,7 +71,6 @@
           connect( ui.checkBoxU,SIGNAL(stateChanged(int)),this,SLOT(valueChanged(int)));
           connect( ui.checkBoxV,SIGNAL(stateChanged(int)),this,SLOT(valueChanged(int))); 
           connect( ui.checkBoxY,SIGNAL(stateChanged(int)),this,SLOT(valueChanged(int)));  
-          connect( ui.checkBox_Enabled,SIGNAL(stateChanged(int)),this,SLOT(previewActivated(int)));  
           connect( ui.toolButton__DVD2PC,SIGNAL(pressed()),this,SLOT(dvd2PC()));  
 
         setModal(true);
@@ -120,16 +115,6 @@ void Ui_contrastWindow::dvd2PC()
   myCrop->sameImage();
   setDialTitles();
   lock--;
-}
-/**
- * 
- * @param a
- */
-void Ui_contrastWindow::previewActivated(int a)
-{
-    previewState=a;
-    myCrop->setState(a);
-    myCrop->sameImage();
 }
 /**
  * 
@@ -238,7 +223,6 @@ void flyContrast::setTabOrder(void)
     PUSH_CHECK(Y)
     PUSH_CHECK(U)
     PUSH_CHECK(V)
-    PUSH_CHECK(_Enabled)
 
     controls.push_back(w->toolButton__DVD2PC);
     controls.insert(controls.end(), buttonList.begin(), buttonList.end());

--- a/avidemux_plugins/ADM_videoFilters6/contrast/qt4/Q_contrast.h
+++ b/avidemux_plugins/ADM_videoFilters6/contrast/qt4/Q_contrast.h
@@ -35,7 +35,6 @@ private:
 protected : 
 	int lock;
         QGraphicsScene *scene;
-        bool            previewState;
 
 public:
 	flyContrast *myCrop;
@@ -50,6 +49,5 @@ public slots:
 private slots:
 	void sliderUpdate(int foo);
 	void valueChanged(int foo);
-        void previewActivated(int a);
         void dvd2PC();
 };

--- a/avidemux_plugins/ADM_videoFilters6/contrast/qt4/contrast.ui
+++ b/avidemux_plugins/ADM_videoFilters6/contrast/qt4/contrast.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>750</width>
-    <height>514</height>
+    <width>721</width>
+    <height>494</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -112,51 +112,31 @@
       <layout class="QVBoxLayout" name="verticalLayout">
        <item>
         <layout class="QGridLayout" name="gridLayout">
-         <item row="2" column="0">
+         <item row="3" column="0">
           <widget class="QCheckBox" name="checkBoxV">
            <property name="text">
             <string>ChromaV</string>
            </property>
           </widget>
          </item>
-         <item row="1" column="0">
+         <item row="2" column="0">
           <widget class="QCheckBox" name="checkBoxU">
            <property name="text">
             <string>ChromaU</string>
            </property>
           </widget>
          </item>
-         <item row="0" column="0">
+         <item row="1" column="0">
           <widget class="QCheckBox" name="checkBoxY">
            <property name="text">
             <string>Luma</string>
            </property>
           </widget>
          </item>
-         <item row="0" column="1">
+         <item row="0" column="0">
           <widget class="QToolButton" name="toolButton__DVD2PC">
            <property name="text">
             <string>MPEG2-&gt;PC</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0">
-          <spacer name="verticalSpacerChroma">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>0</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item row="3" column="0">
-          <widget class="QCheckBox" name="checkBox_Enabled">
-           <property name="text">
-            <string>Process</string>
            </property>
           </widget>
          </item>

--- a/avidemux_plugins/ADM_videoFilters6/delogoHQ/qt4/DIA_flyDelogoHQ.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/delogoHQ/qt4/DIA_flyDelogoHQ.cpp
@@ -77,7 +77,7 @@ uint8_t   flyDelogoHQ::processYuv(ADMImage *in,ADMImage *out )
     }
 
 
-    if (showOriginal || (!mask))
+    if (!mask)
     {
         //out->printString(1,1,"Original");
     } else {

--- a/avidemux_plugins/ADM_videoFilters6/delogoHQ/qt4/DIA_flyDelogoHQ.h
+++ b/avidemux_plugins/ADM_videoFilters6/delogoHQ/qt4/DIA_flyDelogoHQ.h
@@ -22,7 +22,6 @@ class flyDelogoHQ : public ADM_flyDialogYuv
 {
   public:
     delogoHQ         param;
-    bool             showOriginal;
   private:
     int                    rgbBufStride;
     ADM_byteBuffer *       rgbBufRaw;

--- a/avidemux_plugins/ADM_videoFilters6/delogoHQ/qt4/Q_delogoHQ.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/delogoHQ/qt4/Q_delogoHQ.cpp
@@ -49,9 +49,8 @@ Ui_delogoHQWindow::Ui_delogoHQWindow(QWidget *parent, delogoHQ *param,ADM_coreVi
         //memcpy(&(myFly->param),param,sizeof(delogoHQ));
         myFly->param.blur = param->blur;
         myFly->param.gradient = param->gradient;
-        myFly->showOriginal = false;
         myFly->_cookie=&ui;
-        myFly->addControl(ui.toolboxLayout);
+        myFly->addControl(ui.toolboxLayout, true);
         myFly->setTabOrder();
         myFly->upload();
         if(param->maskfile.size())

--- a/avidemux_plugins/ADM_videoFilters6/eq2/qt4/DIA_flyEq2.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/eq2/qt4/DIA_flyEq2.cpp
@@ -110,13 +110,6 @@ uint8_t    flyEq2::processYuv(ADMImage* in, ADMImage *out)
         scene->addLine(qline2,pen);
     }
 
-    if (!fullpreview)
-    {
-        in->copyLeftSideTo(out);
-        out->printString(1,1,"Original"); // printString can't handle non-ascii input, do not translate this!
-        out->printString(in->GetWidth(PLANAR_Y)/24+1,1,"Processed"); // as above, don't try to translate
-    }
-
     return 1;
 }
 

--- a/avidemux_plugins/ADM_videoFilters6/eq2/qt4/DIA_flyEq2.h
+++ b/avidemux_plugins/ADM_videoFilters6/eq2/qt4/DIA_flyEq2.h
@@ -24,7 +24,6 @@ class flyEq2 : public ADM_flyDialogYuv
   public:
     eq2         param;
     QGraphicsScene *scene;
-    bool        fullpreview;
   public:
     uint8_t     processYuv(ADMImage* in, ADMImage *out);
     uint8_t     download(void);

--- a/avidemux_plugins/ADM_videoFilters6/eq2/qt4/Q_eq2.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/eq2/qt4/Q_eq2.cpp
@@ -46,15 +46,13 @@ Ui_eq2Window::Ui_eq2Window(QWidget *parent, eq2 *param,ADM_coreVideoFilter *in) 
     myCrop=new flyEq2(this, width, height,in,canvas,ui.horizontalSlider,scene);
     memcpy(&(myCrop->param),param,sizeof(eq2));
     myCrop->_cookie=&ui;
-    myCrop->fullpreview = false;
-    myCrop->addControl(ui.toolboxLayout);
+    myCrop->addControl(ui.toolboxLayout, true);
     myCrop->setTabOrder();
     myCrop->upload();
     myCrop->sliderChanged();
     myCrop->update();
 
     ui.horizontalSliderContrast->setFocus();
-    ui.checkBoxFullPreview->setChecked(myCrop->fullpreview);
 
     QSignalMapper *signalMapper = new QSignalMapper(this);
     connect( signalMapper,SIGNAL(mapped(QWidget*)),this,SLOT(resetSlider(QWidget*)));
@@ -77,7 +75,6 @@ Ui_eq2Window::Ui_eq2Window(QWidget *parent, eq2 *param,ADM_coreVideoFilter *in) 
     SPINNER(Blue);
     SPINNER(Green);
 
-    connect( ui.checkBoxFullPreview,SIGNAL(stateChanged(int)),this,SLOT(toggleFullPreview(int)));
 
     setResetSliderEnabledState();
 
@@ -158,20 +155,6 @@ void Ui_eq2Window::setResetSliderEnabledState(void)
     CAN_RESET(Red,initialValues[5])
     CAN_RESET(Blue,initialValues[6])
     CAN_RESET(Green,initialValues[7])
-}
-
-/**
- * \fn toggleFullPreview
- */
-void Ui_eq2Window::toggleFullPreview(int checkState)
-{
-    bool fullpreview=false;
-    if(checkState)
-    {
-        fullpreview=true;
-    }
-    myCrop->fullpreview=fullpreview;
-    myCrop->sameImage();
 }
 
 /**
@@ -292,7 +275,6 @@ void flyEq2::setTabOrder(void)
 
     controls.insert(controls.end(), buttonList.begin(), buttonList.end());
     controls.push_back(w->horizontalSlider);
-    controls.push_back(w->checkBoxFullPreview);
 
     QWidget *first, *second;
 

--- a/avidemux_plugins/ADM_videoFilters6/eq2/qt4/Q_eq2.h
+++ b/avidemux_plugins/ADM_videoFilters6/eq2/qt4/Q_eq2.h
@@ -47,7 +47,6 @@ private slots:
     void sliderUpdate(int foo);
     void valueChanged(int foo);
     void resetSlider(QWidget *control);
-    void toggleFullPreview(int checkState);
 
 private:
     void resizeEvent(QResizeEvent *event);

--- a/avidemux_plugins/ADM_videoFilters6/eq2/qt4/eq2.ui
+++ b/avidemux_plugins/ADM_videoFilters6/eq2/qt4/eq2.ui
@@ -99,13 +99,6 @@
          </property>
         </widget>
        </item>
-       <item>
-        <widget class="QCheckBox" name="checkBoxFullPreview">
-         <property name="text">
-          <string>Show full preview</string>
-         </property>
-        </widget>
-       </item>
       </layout>
      </item>
      <item>

--- a/avidemux_plugins/ADM_videoFilters6/hue/qt4/DIA_flyHue.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/hue/qt4/DIA_flyHue.cpp
@@ -50,12 +50,6 @@ uint8_t   flyHue::processYuv(ADMImage *in,ADMImage *out )
                  in->GetReadPtr(PLANAR_U), in->GetReadPtr(PLANAR_V),
                  out->GetPitch(PLANAR_U), in->GetPitch(PLANAR_U), // assume u&v pitches are =
                  _w>>1, _h>>1, &flyset);
-    if(fullpreview)
-        return 1;
-    // Copy half source to display
-    in->copyLeftSideTo(out);
-    out->printString(1,1,"Original"); // printString can't handle non-ascii input, do not translate this!
-    out->printString(in->GetWidth(PLANAR_Y)/24+1,1,"Processed"); // as above, don't try to translate
 
     return 1;
 }

--- a/avidemux_plugins/ADM_videoFilters6/hue/qt4/DIA_flyHue.h
+++ b/avidemux_plugins/ADM_videoFilters6/hue/qt4/DIA_flyHue.h
@@ -24,7 +24,6 @@ class flyHue : public ADM_flyDialogYuv
   private:
     huesettings flyset;
   public:
-    bool        fullpreview;
 
     uint8_t     processYuv(ADMImage* in, ADMImage *out);
     uint8_t     download(void);
@@ -32,8 +31,7 @@ class flyHue : public ADM_flyDialogYuv
     uint8_t     update(void);
     uint8_t     reset(void);
                 flyHue(QDialog *parent, uint32_t width, uint32_t height, ADM_coreVideoFilter *in,
-                     ADM_QCanvas *canvas, ADM_QSlider *slider) : ADM_flyDialogYuv(parent, width, height, in, canvas, slider, RESIZE_AUTO)
-                { fullpreview = false; }
+                     ADM_QCanvas *canvas, ADM_QSlider *slider) : ADM_flyDialogYuv(parent, width, height, in, canvas, slider, RESIZE_AUTO) {}
     void        setTabOrder(void);
     void        setParam(hue *par) { flyset.param.hue = par->hue; flyset.param.saturation = par->saturation; }
     void        getParam(hue *par) { par->hue = flyset.param.hue; par->saturation = flyset.param.saturation; }

--- a/avidemux_plugins/ADM_videoFilters6/hue/qt4/Q_hue.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/hue/qt4/Q_hue.cpp
@@ -43,7 +43,7 @@
         myCrop=new flyHue( this,width, height,in,canvas,ui.horizontalSlider);
         myCrop->setParam(param);
         myCrop->_cookie=&ui;
-        myCrop->addControl(ui.toolboxLayout);
+        myCrop->addControl(ui.toolboxLayout, true);
         myCrop->setTabOrder();
         myCrop->upload();
         myCrop->sliderChanged();
@@ -54,8 +54,6 @@
 #define SPINNER(x) connect( ui.horizontalSlider##x,SIGNAL(valueChanged(int)),this,SLOT(valueChanged(int))); 
           SPINNER(Hue);
           SPINNER(Saturation);
-
-        connect(ui.checkBoxFullPreview,SIGNAL(stateChanged(int)),this,SLOT(toggleFullPreview(int)));
 
         QPushButton *resetButton = ui.buttonBox->button(QDialogButtonBox::Reset);
         connect(resetButton,SIGNAL(clicked()),this,SLOT(reset()));
@@ -85,14 +83,6 @@ void Ui_hueWindow::valueChanged( int f )
    myCrop->download();
   myCrop->sameImage();
   lock--;
-}
-void Ui_hueWindow::toggleFullPreview(int state)
-{
-    if(lock) return;
-    lock++;
-    myCrop->fullpreview = state != Qt::Unchecked;
-    myCrop->sameImage();
-    lock--;
 }
 
 void Ui_hueWindow::reset(void)
@@ -131,15 +121,12 @@ uint8_t flyHue::upload(void)
 
     MYSPIN(Saturation)->blockSignals(true);
     MYSPIN(Hue)->blockSignals(true);
-    MYCHECK(FullPreview)->blockSignals(true);
 
     MYSPIN(Saturation)->setValue((int)(flyset.param.saturation*10));
     MYSPIN(Hue)->setValue((int)flyset.param.hue);
-    MYCHECK(FullPreview)->setChecked(fullpreview);
 
     MYSPIN(Saturation)->blockSignals(false);
     MYSPIN(Hue)->blockSignals(false);
-    MYCHECK(FullPreview)->blockSignals(false);
 
     update();
 
@@ -166,7 +153,6 @@ void flyHue::setTabOrder(void)
     controls.insert(controls.end(), buttonList.begin(), buttonList.end());
     controls.push_back(w->horizontalSlider);
     //controls.push_back(w->graphicsView);
-    controls.push_back(MYCHECK(FullPreview));
 #if 0 /* don't mess with button box */
     controls.push_back(w->buttonBox->button(QDialogButtonBox::Reset));
     { // button box stuff

--- a/avidemux_plugins/ADM_videoFilters6/hue/qt4/Q_hue.h
+++ b/avidemux_plugins/ADM_videoFilters6/hue/qt4/Q_hue.h
@@ -25,7 +25,6 @@ public slots:
 private slots:
     void sliderUpdate(int foo);
     void valueChanged(int foo);
-    void toggleFullPreview(int foo);
     void reset(void);
 
 private:

--- a/avidemux_plugins/ADM_videoFilters6/hue/qt4/hue.ui
+++ b/avidemux_plugins/ADM_videoFilters6/hue/qt4/hue.ui
@@ -108,13 +108,6 @@
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="checkBoxFullPreview">
-     <property name="text">
-      <string>Show full preview</string>
-     </property>
-    </widget>
-   </item>
-   <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>

--- a/avidemux_plugins/ADM_videoFilters6/mSharpen/qt4/DIA_flymsharpen.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/mSharpen/qt4/DIA_flymsharpen.cpp
@@ -49,7 +49,6 @@
  {
      blur=  new ADMImageDefault(_w/2,_h);
      work=  new ADMImageDefault(_w,_h);;     //<-dafuq ?
-     fullpreview = false;
  }
  /**
   * 
@@ -69,7 +68,6 @@ flyMSharpen::~flyMSharpen()
 uint8_t    flyMSharpen::processYuv(ADMImage* in, ADMImage *out)
 {
     uint32_t outw = _w;
-    if(!fullpreview) outw >>= 1;
     if(blur->_width != outw)
     {
         delete blur;
@@ -79,15 +77,13 @@ uint8_t    flyMSharpen::processYuv(ADMImage* in, ADMImage *out)
     ADMImageRef          refIn(outw,_h);
     ADMImageRefWrittable refOut(outw,_h);
 
-    if(!fullpreview)
-        in->copyLeftSideTo(out);
     for(int i=0;i<3;i++)
     {
         int halfWidth=in->GetWidth((ADM_PLANE)i)/2; // in and out have the same width
         refIn._planeStride[i] =in->_planeStride[i];
         refOut._planeStride[i]=out->_planeStride[i];
         refIn._planes[i]      =in->_planes[i];//+halfWidth;
-        refOut._planes[i] = fullpreview ? out->_planes[i] : out->_planes[i] + halfWidth;
+        refOut._planes[i] = out->_planes[i];
     }
     
     for (int i=0;i<(param.chroma ? 3:1);i++)
@@ -105,10 +101,6 @@ uint8_t    flyMSharpen::processYuv(ADMImage* in, ADMImage *out)
         (&refOut)->copyPlane(&refIn,&refOut,PLANAR_V);
     }
     out->copyInfo(in);
-    if(fullpreview)
-        return 1;
-    out->printString(1,1,"Original"); // printString can't handle non-ascii input, do not translate this!
-    out->printString(in->GetWidth(PLANAR_Y)/24+1,1,"Processed"); // as above, don't try to translate
 
     return 1;
 }
@@ -132,7 +124,6 @@ uint8_t flyMSharpen::upload()
     MYTOGGLE(Chroma,chroma)
 #undef MYSPIN
 #undef MYTOGGLE
-    w->checkBoxFullPreview->setChecked(fullpreview);
     blockChanges(false);
     invstrength = 255-param.strength;
     return 1;
@@ -154,7 +145,6 @@ uint8_t flyMSharpen::download(void)
     MYTOGGLE(Chroma,chroma)
 #undef MYSPIN
 #undef MYTOGGLE
-    fullpreview = w->checkBoxFullPreview->isChecked();
     blockChanges(false);
     if(param.strength > 255) param.strength=255;
     invstrength = 255-param.strength;
@@ -165,7 +155,7 @@ uint8_t flyMSharpen::download(void)
 */
 #define APPLY_TO_ALL(x) w->horizontalSliderThreshold->x; w->horizontalSliderStrength->x; \
                         w->spinBoxThreshold->x; w->spinBoxStrength->x; \
-                        w->checkBoxHQ->x; w->checkBoxChroma->x; w->checkBoxMask->x; w->checkBoxFullPreview;
+                        w->checkBoxHQ->x; w->checkBoxChroma->x; w->checkBoxMask->x;
 void flyMSharpen::blockChanges(bool block)
 {
     Ui_msharpenDialog *w=(Ui_msharpenDialog *)_cookie;
@@ -188,7 +178,6 @@ void flyMSharpen::setTabOrder(void)
     MYTOGGLE(HQ)
     MYTOGGLE(Chroma)
     MYTOGGLE(Mask)
-    MYTOGGLE(FullPreview)
 
     controls.insert(controls.end(), buttonList.begin(), buttonList.end());
     controls.push_back(w->horizontalSlider);

--- a/avidemux_plugins/ADM_videoFilters6/mSharpen/qt4/DIA_flymsharpen.h
+++ b/avidemux_plugins/ADM_videoFilters6/mSharpen/qt4/DIA_flymsharpen.h
@@ -24,7 +24,6 @@ protected:
    ADMImage    *blur,*work;
 public:
    msharpen    param;
-   bool        fullpreview;
 
    uint8_t     processYuv(ADMImage* in, ADMImage *out);
    uint8_t     download(void);

--- a/avidemux_plugins/ADM_videoFilters6/mSharpen/qt4/Q_msharpen.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/mSharpen/qt4/Q_msharpen.cpp
@@ -41,7 +41,7 @@
         flymsharpen=new flyMSharpen( this,width, height,in,canvas,ui.horizontalSlider);
         memcpy(&(flymsharpen->param),param,sizeof(*param));
         flymsharpen->_cookie=&ui;
-        flymsharpen->addControl(ui.toolboxLayout);
+        flymsharpen->addControl(ui.toolboxLayout, true);
         flymsharpen->setTabOrder();
         flymsharpen->upload();
         flymsharpen->sliderChanged();
@@ -62,7 +62,6 @@
 
         QPushButton *resetButton = ui.buttonBox->button(QDialogButtonBox::Reset);
         connect(resetButton,SIGNAL(clicked(bool)),this,SLOT(reset(bool)));
-        connect(ui.checkBoxFullPreview,SIGNAL(stateChanged(int)),this,SLOT(toggleFullPreview(int)));
 
         setModal(true);
   }
@@ -90,14 +89,6 @@ void Ui_msharpenWindow::valueChanged( int f )
   flymsharpen->download();
   flymsharpen->sameImage();
   lock--;
-}
-void Ui_msharpenWindow::toggleFullPreview(int state)
-{
-    if(lock) return;
-    lock++;
-    flymsharpen->fullpreview = state != Qt::Unchecked;
-    flymsharpen->sameImage();
-    lock--;
 }
 void Ui_msharpenWindow::reset(bool checked)
 {

--- a/avidemux_plugins/ADM_videoFilters6/mSharpen/qt4/Q_msharpen.h
+++ b/avidemux_plugins/ADM_videoFilters6/mSharpen/qt4/Q_msharpen.h
@@ -22,7 +22,6 @@ public slots:
 private slots:
         void sliderUpdate(int foo);
         void valueChanged(int foo);
-        void toggleFullPreview(int state);
         void reset(bool checked);
 	void valueChangedSlider(int foo);
 

--- a/avidemux_plugins/ADM_videoFilters6/mSharpen/qt4/msharpen.ui
+++ b/avidemux_plugins/ADM_videoFilters6/mSharpen/qt4/msharpen.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>481</width>
-    <height>454</height>
+    <width>551</width>
+    <height>382</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -39,30 +39,7 @@
    </item>
    <item row="0" column="0">
     <layout class="QGridLayout" name="mainControls">
-     <item row="0" column="2">
-      <widget class="QSpinBox" name="spinBoxStrength">
-       <property name="minimum">
-        <number>0</number>
-       </property>
-       <property name="maximum">
-        <number>255</number>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="3">
-      <spacer>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="2" column="1">
+     <item row="3" column="1">
       <widget class="QCheckBox" name="checkBoxChroma">
        <property name="text">
         <string>Process chroma</string>
@@ -76,17 +53,7 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="1">
-      <widget class="QSlider" name="horizontalSliderStrength">
-       <property name="maximum">
-        <number>255</number>
-       </property>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
+     <item row="3" column="0">
       <widget class="QCheckBox" name="checkBoxHQ">
        <property name="text">
         <string>HighQuality</string>
@@ -100,7 +67,24 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="2">
+     <item row="3" column="2">
+      <widget class="QCheckBox" name="checkBoxMask">
+       <property name="text">
+        <string>Mask</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="4">
+      <widget class="QSpinBox" name="spinBoxStrength">
+       <property name="minimum">
+        <number>0</number>
+       </property>
+       <property name="maximum">
+        <number>255</number>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="4">
       <widget class="QSpinBox" name="spinBoxThreshold">
        <property name="minimum">
         <number>0</number>
@@ -110,7 +94,30 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
+     <item row="0" column="5">
+      <spacer>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="0" column="1" colspan="3">
+      <widget class="QSlider" name="horizontalSliderStrength">
+       <property name="maximum">
+        <number>255</number>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1" colspan="3">
       <widget class="QSlider" name="horizontalSliderThreshold">
        <property name="maximum">
         <number>255</number>
@@ -120,19 +127,18 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
-      <widget class="QCheckBox" name="checkBoxFullPreview">
-       <property name="text">
-        <string>Show full preview</string>
+     <item row="3" column="3">
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
        </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QCheckBox" name="checkBoxMask">
-       <property name="text">
-        <string>Mask</string>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
        </property>
-      </widget>
+      </spacer>
      </item>
     </layout>
    </item>

--- a/avidemux_plugins/ADM_videoFilters6/waveletDenoise/qt4/DIA_flyWaveletDenoise.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/waveletDenoise/qt4/DIA_flyWaveletDenoise.cpp
@@ -35,14 +35,8 @@ uint8_t   flyWaveletDenoise::processYuv(ADMImage *in,ADMImage *out )
 {
     out->duplicate(in);
 
-    if (showOriginal)
-    {
-        out->printString(1,1,"Original");
-    } else {
-        // Do it!
-        ADMVideoWaveletDenoise::WaveletDenoiseProcess_C(out, param.threshold, param.softness, param.highq, param.chroma);
-        out->printString(1,1,"Processed"); 
-    }
+    // Do it!
+    ADMVideoWaveletDenoise::WaveletDenoiseProcess_C(out, param.threshold, param.softness, param.highq, param.chroma);
 
     return 1;
 }

--- a/avidemux_plugins/ADM_videoFilters6/waveletDenoise/qt4/DIA_flyWaveletDenoise.h
+++ b/avidemux_plugins/ADM_videoFilters6/waveletDenoise/qt4/DIA_flyWaveletDenoise.h
@@ -23,7 +23,6 @@ class flyWaveletDenoise : public ADM_flyDialogYuv
 
   public:
     waveletDenoise  param;
-    bool          showOriginal;
   public:
     uint8_t    processYuv(ADMImage* in, ADMImage *out);
     uint8_t    download(void);

--- a/avidemux_plugins/ADM_videoFilters6/waveletDenoise/qt4/Q_waveletDenoise.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/waveletDenoise/qt4/Q_waveletDenoise.cpp
@@ -43,9 +43,8 @@ Ui_waveletDenoiseWindow::Ui_waveletDenoiseWindow(QWidget *parent, waveletDenoise
 
         myFly=new flyWaveletDenoise( this,width, height,in,canvas,ui.horizontalSlider);
         memcpy(&(myFly->param),param,sizeof(waveletDenoise));
-        myFly->showOriginal = false;
         myFly->_cookie=&ui;
-        myFly->addControl(ui.toolboxLayout);
+        myFly->addControl(ui.toolboxLayout, true);
         myFly->setTabOrder();
         myFly->upload();
         myFly->sliderChanged();
@@ -59,9 +58,6 @@ Ui_waveletDenoiseWindow::Ui_waveletDenoiseWindow(QWidget *parent, waveletDenoise
 #define TOGGLER(x) connect(ui.checkBox##x,SIGNAL(stateChanged(int)),this,SLOT(valueChanged(int)));
         TOGGLER(HQ)
         TOGGLER(Chroma)
-
-        connect( ui.pushButtonPeek,SIGNAL(pressed()),this,SLOT(peekPressed()));
-        connect( ui.pushButtonPeek,SIGNAL(released()),this,SLOT(peekReleased()));
 
 
         QPushButton *resetButton = ui.buttonBox->button(QDialogButtonBox::Reset);
@@ -99,22 +95,6 @@ void Ui_waveletDenoiseWindow::reset(void)
     lock++;
     ADMVideoWaveletDenoise::reset(&myFly->param);
     myFly->upload();
-    myFly->sameImage();
-    lock--;
-}
-void Ui_waveletDenoiseWindow::peekPressed(void)
-{
-    myFly->showOriginal = true;
-    if(lock) return;
-    lock++;
-    myFly->sameImage();
-    lock--;
-}
-void Ui_waveletDenoiseWindow::peekReleased(void)
-{
-    myFly->showOriginal = false;
-    if(lock) return;
-    lock++;
     myFly->sameImage();
     lock--;
 }
@@ -167,7 +147,6 @@ void flyWaveletDenoise::setTabOrder(void)
     PUSH_SPIN(Softness)
     PUSH_TOG(HQ)
     PUSH_TOG(Chroma)
-    controls.push_back(w->pushButtonPeek);
 
 
     controls.insert(controls.end(), buttonList.begin(), buttonList.end());

--- a/avidemux_plugins/ADM_videoFilters6/waveletDenoise/qt4/Q_waveletDenoise.h
+++ b/avidemux_plugins/ADM_videoFilters6/waveletDenoise/qt4/Q_waveletDenoise.h
@@ -26,8 +26,6 @@ class Ui_waveletDenoiseWindow : public QDialog
     void sliderUpdate(int foo);
     void valueChanged(int foo);
     void reset(void);
-    void peekPressed(void);
-    void peekReleased(void);
 
   private:
     void resizeEvent(QResizeEvent *event);

--- a/avidemux_plugins/ADM_videoFilters6/waveletDenoise/qt4/waveletDenoise.ui
+++ b/avidemux_plugins/ADM_videoFilters6/waveletDenoise/qt4/waveletDenoise.ui
@@ -129,31 +129,7 @@
     </layout>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <layout class="QHBoxLayout" name="toolboxLayout"/>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButtonPeek">
-       <property name="text">
-        <string>Peek Original</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <layout class="QHBoxLayout" name="toolboxLayout"/>
    </item>
    <item>
     <widget class="ADM_QSlider" name="horizontalSlider">

--- a/avidemux_plugins/ADM_videoFilters6/waveletSharp/qt4/DIA_flyWaveletSharp.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/waveletSharp/qt4/DIA_flyWaveletSharp.cpp
@@ -35,14 +35,8 @@ uint8_t   flyWaveletSharp::processYuv(ADMImage *in,ADMImage *out )
 {
     out->duplicate(in);
 
-    if (showOriginal)
-    {
-        out->printString(1,1,"Original");
-    } else {
-        // Do it!
-        ADMVideoWaveletSharp::WaveletSharpProcess_C(out, param.strength, param.radius, param.highq);
-        out->printString(1,1,"Processed"); 
-    }
+    // Do it!
+    ADMVideoWaveletSharp::WaveletSharpProcess_C(out, param.strength, param.radius, param.highq);
 
     return 1;
 }

--- a/avidemux_plugins/ADM_videoFilters6/waveletSharp/qt4/DIA_flyWaveletSharp.h
+++ b/avidemux_plugins/ADM_videoFilters6/waveletSharp/qt4/DIA_flyWaveletSharp.h
@@ -23,7 +23,6 @@ class flyWaveletSharp : public ADM_flyDialogYuv
 
   public:
     waveletSharp  param;
-    bool          showOriginal;
   public:
     uint8_t    processYuv(ADMImage* in, ADMImage *out);
     uint8_t    download(void);

--- a/avidemux_plugins/ADM_videoFilters6/waveletSharp/qt4/Q_waveletSharp.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/waveletSharp/qt4/Q_waveletSharp.cpp
@@ -43,9 +43,8 @@ Ui_waveletSharpWindow::Ui_waveletSharpWindow(QWidget *parent, waveletSharp *para
 
         myFly=new flyWaveletSharp( this,width, height,in,canvas,ui.horizontalSlider);
         memcpy(&(myFly->param),param,sizeof(waveletSharp));
-        myFly->showOriginal = false;
         myFly->_cookie=&ui;
-        myFly->addControl(ui.toolboxLayout);
+        myFly->addControl(ui.toolboxLayout, true);
         myFly->setTabOrder();
         myFly->upload();
         myFly->sliderChanged();
@@ -58,9 +57,6 @@ Ui_waveletSharpWindow::Ui_waveletSharpWindow(QWidget *parent, waveletSharp *para
 
 #define TOGGLER(x) connect(ui.checkBox##x,SIGNAL(stateChanged(int)),this,SLOT(valueChanged(int)));
         TOGGLER(HQ)
-
-        connect( ui.pushButtonPeek,SIGNAL(pressed()),this,SLOT(peekPressed()));
-        connect( ui.pushButtonPeek,SIGNAL(released()),this,SLOT(peekReleased()));
 
 
         QPushButton *resetButton = ui.buttonBox->button(QDialogButtonBox::Reset);
@@ -98,22 +94,6 @@ void Ui_waveletSharpWindow::reset(void)
     lock++;
     ADMVideoWaveletSharp::reset(&myFly->param);
     myFly->upload();
-    myFly->sameImage();
-    lock--;
-}
-void Ui_waveletSharpWindow::peekPressed(void)
-{
-    myFly->showOriginal = true;
-    if(lock) return;
-    lock++;
-    myFly->sameImage();
-    lock--;
-}
-void Ui_waveletSharpWindow::peekReleased(void)
-{
-    myFly->showOriginal = false;
-    if(lock) return;
-    lock++;
     myFly->sameImage();
     lock--;
 }
@@ -163,7 +143,6 @@ void flyWaveletSharp::setTabOrder(void)
     PUSH_SPIN(Strength)
     PUSH_SPIN(Radius)
     PUSH_TOG(HQ)
-    controls.push_back(w->pushButtonPeek);
 
 
     controls.insert(controls.end(), buttonList.begin(), buttonList.end());

--- a/avidemux_plugins/ADM_videoFilters6/waveletSharp/qt4/Q_waveletSharp.h
+++ b/avidemux_plugins/ADM_videoFilters6/waveletSharp/qt4/Q_waveletSharp.h
@@ -26,8 +26,6 @@ class Ui_waveletSharpWindow : public QDialog
     void sliderUpdate(int foo);
     void valueChanged(int foo);
     void reset(void);
-    void peekPressed(void);
-    void peekReleased(void);
 
   private:
     void resizeEvent(QResizeEvent *event);

--- a/avidemux_plugins/ADM_videoFilters6/waveletSharp/qt4/waveletSharp.ui
+++ b/avidemux_plugins/ADM_videoFilters6/waveletSharp/qt4/waveletSharp.ui
@@ -122,31 +122,7 @@
     </layout>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <layout class="QHBoxLayout" name="toolboxLayout"/>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButtonPeek">
-       <property name="text">
-        <string>Peek Original</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <layout class="QHBoxLayout" name="toolboxLayout"/>
    </item>
    <item>
     <widget class="ADM_QSlider" name="horizontalSlider">


### PR DESCRIPTION
Optional through ADM_flyDialog::addControl(QHBoxLayout *layout, bool addPeekOriginalButton = false);

Applied to most of the art filters, chromaShift, colorTemp, blur and DelogoHQ.
In waveletSharp and waveletDenoise the built in Peek Original buttons were replaced with this.

In contrast, eq2, hue, asharp and mSharpen the old and diverse preview modes were deleted, and Peek Original buttons were added.