### PR TITLE
[crop/qt5] improvements

### DIFF
--- a/avidemux_plugins/ADM_videoFilters6/crop/qt5/DIA_flyCrop.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/crop/qt5/DIA_flyCrop.cpp
@@ -348,8 +348,8 @@ bool    flyCrop::bandMoved(int x,int y,int w, int h)
 
     // bound checks are done in rubber control
 
-    right=bound(normX,normW,_w)&0xfffe;
-    bottom=bound(normY,normH,_h)&0xfffe;
+    right=bound(normX&0xfffe,normW,_w)&0xfffe;
+    bottom=bound(normY&0xfffe,normH,_h)&0xfffe;
 
     if(normX<0) normX=0;
     if(normY<0) normY=0;

--- a/avidemux_plugins/ADM_videoFilters6/crop/qt5/DIA_flyCrop.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/crop/qt5/DIA_flyCrop.cpp
@@ -148,15 +148,18 @@ int flyCrop::lockRubber(bool lock)
 
 static void blank(uint8_t *in, int w, int h, int stride)
 {
+    uint32_t * tmp;
     for(int y=0;y<h;y++)
     {
-        memset(in,0,4*w);
-        uint8_t *green=in+1;
+        tmp = (uint32_t*)in;
         for(int x=0;x<w;x++)
-            green[x<<2]=0xff;
-        uint8_t *alpha=in+3;
-        for(int x=0;x<w;x++)
-            alpha[x<<2]=0xff;
+        {
+            *tmp >>= 2;
+            *tmp &= 0xFF3F3F3F;
+            *tmp |= 0xFF000000;
+            *tmp += (192 << 8);
+            tmp += 1;
+        }
         in+=stride;
     }
 }


### PR DESCRIPTION
1) Replace green blanking with green alpha blending.
It makes repositioning easier.
It also provides visible guide lines (bug turned out to be a feature :-) ).

2) Prevent dimension jitter on rubber band move.