### PR TITLE
[coreVideoFilter] Rebuilding bridge on opening filter manager

### DIFF
--- a/avidemux/qt4/ADM_userInterfaces/ADM_filters/Q_mainfilter.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_filters/Q_mainfilter.cpp
@@ -748,6 +748,7 @@ filtermainWindow::filtermainWindow(QWidget* parent) : QDialog(parent)
     connect(ui.buttonClose, SIGNAL(clicked(bool)), this, SLOT(accept()));
     connect(ui.pushButtonPreview, SIGNAL(clicked(bool)), this, SLOT(preview(bool)));
 
+    ADM_vf_rebuildBridge(video_body);
     displayFamily(0);
     buildActiveFilterList();
     setSelected(nb_active_filter - 1);

--- a/avidemux_core/ADM_coreVideoFilter/include/ADM_coreVideoFilterFunc.h
+++ b/avidemux_core/ADM_coreVideoFilter/include/ADM_coreVideoFilterFunc.h
@@ -14,5 +14,6 @@ ADM_COREVIDEOFILTER6_EXPORT ADM_coreVideoFilter *ADM_vf_createFromTag(uint32_t t
 ADM_COREVIDEOFILTER6_EXPORT ADM_VideoFilterElement* ADM_vf_insertFilterFromTag(IEditor *editor, uint32_t tag, CONFcouple *c, int index);
 ADM_COREVIDEOFILTER6_EXPORT ADM_VideoFilterElement* ADM_vf_addFilterFromTag(IEditor *editor, uint32_t tag, CONFcouple *c, bool configure);
 ADM_coreVideoFilter *ADM_vf_getLastVideoFilter(IEditor *editor);
+ADM_COREVIDEOFILTER6_EXPORT void ADM_vf_rebuildBridge(IEditor *editor);
 
 #endif

--- a/avidemux_core/ADM_coreVideoFilter/src/ADM_coreVideoFilterFunc.cpp
+++ b/avidemux_core/ADM_coreVideoFilter/src/ADM_coreVideoFilterFunc.cpp
@@ -227,3 +227,15 @@ ADM_coreVideoFilter *ADM_vf_getLastVideoFilter(IEditor *editor)
 
     return last;
 }
+
+/**
+    \fn rebuildBridge
+*/
+void ADM_vf_rebuildBridge(IEditor *editor)
+{
+    if (!bridge)
+        return;
+    delete bridge;
+    bridge = new ADM_videoFilterBridge(editor, 0, -1LL);
+    ADM_vf_recreateChain();
+}


### PR DESCRIPTION
Rebuild bridge and recreate filter chain when the user opens the video filter manager, to update timing info from the editor.
Bugfix for:
1) Video filter preview sometimes only show the fraction of the video, and the reported length is shorter too.
2) Video filter preview sometimes reports the original length, altough sections have been already cut out.