### PR TITLE
[fadeTo] alleviate erratic preview behaviour

### DIFF
--- a/avidemux_plugins/ADM_videoFilters6/fadeTo/ADM_vidFadeTo.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/fadeTo/ADM_vidFadeTo.cpp
@@ -229,6 +229,11 @@ bool AVDM_FadeTo::getNextFrame(uint32_t *fn,ADMImage *image)
     }
     if( out_of_scope || !first)
     {
+        if(first)
+        {
+            delete first;
+            first=NULL;
+        }
         image->duplicate(next);
         nextFrame++;
         vidCache->unlockAll();


### PR DESCRIPTION
When seeking in the preview, and seek into the filter scope (its a keyframe, but not the acutal first frame), it will stuck with the wrong frame.
This is not an absolute fix, just an alleviation.
