### PR TITLE
[ADM_edCache] shared cache

### DIFF
--- a/avidemux/common/ADM_editor/include/ADM_edCache.h
+++ b/avidemux/common/ADM_editor/include/ADM_edCache.h
@@ -22,6 +22,7 @@ typedef struct cacheElem
 {
 	ADMImage *image;
     uint64_t pts;       // If set to ADM_NO_PTS -> unused entry
+    int instance;
 }cacheElem;
 /**
     \class EditorCache
@@ -30,9 +31,12 @@ typedef struct cacheElem
 class EditorCache
 {
 	private :
-			uint32_t     readIndex,writeIndex;
-			cacheElem	 *_elem;
-			uint32_t	_nbImage;
+            static int          _instanceCount;
+            int                 myInstance;
+			static uint32_t     readIndex,writeIndex;
+            static uint32_t     _commonW,_commonH;
+			static cacheElem	*_elem;
+			static uint32_t	    _nbImage;
             void        check(void);
 	public:
                         EditorCache(uint32_t size,uint32_t w, uint32_t h);

--- a/avidemux/common/ADM_editor/src/utils/ADM_edCache.cpp
+++ b/avidemux/common/ADM_editor/src/utils/ADM_edCache.cpp
@@ -79,6 +79,7 @@ EditorCache::EditorCache(uint32_t size,uint32_t w, uint32_t h)
 */
 EditorCache::~EditorCache(void)
 {
+    flush();
     _instanceCount--;
     if (_instanceCount > 0)
         return;
@@ -134,6 +135,7 @@ ADMImage *EditorCache::getFreeImage(void)
     // Mark it as used
     if(found==-1) ADM_assert(0);
     _elem[found].pts=ADM_NO_PTS;;
+    _elem[found].image->hwDecRefCount();
     writeIndex++;
     aprintf("Using free image at index %d\n",found);
     return _elem[found].image;


### PR DESCRIPTION
Reduce memory usage when appending multiple files.
Tested with appending 30 short files (4k resolution). The total duration is less than 2 min.
Before: 12 GB RAM usage
With the commit: 6 GB RAM usage (so there is still something that eats the memory (decoder?) )

Mixed HW and SW decoded appending needs further confirmation.

PS: i managed to get VDPAU to work with my low end AMD card (no VP9). Appending a HW and a SW decoded file, there is no new error when using this shared cache. 

PS+OT: Appending a HW and a SW decoded file, the SW decoded part not working, the editor shows the last HW decoded frame during seeking/playing in the SW decoded part. Same behaviour with 2.7.6 appimage.