### PR TITLE
Markers...

### DIFF
--- a/avidemux/common/ADM_videoFilter2/src/ADM_vidPartial.cpp
+++ b/avidemux/common/ADM_videoFilter2/src/ADM_vidPartial.cpp
@@ -61,6 +61,7 @@ protected:
                 bool         hasIntermediate;
                 uint32_t     intermediateFn;
                 bool         sonFilterPreview;
+                FilterInfo   previewFilterInfo;
 
 
                 bool        isInRange(uint64_t tme);
@@ -72,6 +73,7 @@ public:
         virtual const char   *getConfiguration(void);                   /// Return  current configuration as a human readable string
         virtual bool         getNextFrame(uint32_t *fn,ADMImage *image);    /// Return the next image
         virtual bool         getNextFrameForSon(uint32_t *fn,ADMImage *image);    /// Return the next image
+        virtual FilterInfo   *getInfo(void);
         virtual bool         getCoupledConf(CONFcouple **couples) ;     /// Return the current filter configuration
         virtual void         setCoupledConf(CONFcouple *couples);
         virtual bool         configure(void); /// Start graphical user interface
@@ -226,6 +228,20 @@ bool partialFilter::getNextFrame(uint32_t *fn,ADMImage *image)
          return false;
     }
     return true;
+}
+
+/**
+    \fn getInfo
+    \brief Get FilterInfo
+*/
+FilterInfo  *partialFilter::getInfo(void)
+{
+    if (!sonFilterPreview)
+        return previousFilter->getInfo();
+    
+    previewFilterInfo = *(previousFilter->getInfo());
+    getRange(&(previewFilterInfo.markerA), &(previewFilterInfo.markerB));
+    return &previewFilterInfo;
 }
 
 /**

--- a/avidemux/qt4/ADM_UIs/src/DIA_flyDialog.cpp
+++ b/avidemux/qt4/ADM_UIs/src/DIA_flyDialog.cpp
@@ -604,7 +604,10 @@ bool FlyDialogEventFilter::eventFilter(QObject *obj, QEvent *event)
     _zoomChangeCount = 0;        
     _yuvBuffer=new ADMImageDefault(_w,_h);
     _usedWidth= _usedHeight=0;
-    lastPts=0;
+    lastPts= _in->getInfo()->markerA;
+    setCurrentPts(lastPts);
+    _in->goToTime(lastPts);
+    updateSlider();
     _bypassFilter=false;
 
     QGraphicsScene *sc=new QGraphicsScene(this);

--- a/avidemux/qt4/ADM_userInterfaces/ADM_filters/Q_mainfilter.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_filters/Q_mainfilter.cpp
@@ -289,7 +289,7 @@ void filtermainWindow::preview(bool b)
         title += QT_TRANSLATE_NOOP("qmainfilter","DISABLED ");
     title += QString::fromUtf8(name);
 
-    previewDialog = new Ui_seekablePreviewWindow(this, filter, 0);
+    previewDialog = new Ui_seekablePreviewWindow(this, filter);
     previewDialog->setWindowTitle(title);
     previewDialog->setModal(true);
     connect(previewDialog, SIGNAL(accepted()), this, SLOT(closePreview()));

--- a/avidemux/qt4/ADM_userInterfaces/ADM_filters/Q_seekablePreview.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_filters/Q_seekablePreview.cpp
@@ -23,7 +23,7 @@
  * @param videoStream
  * @param defaultFrame
  */
-Ui_seekablePreviewWindow::Ui_seekablePreviewWindow(QWidget *parent, ADM_coreVideoFilter *videoStream, uint32_t defaultFrame) : QDialog(parent)
+Ui_seekablePreviewWindow::Ui_seekablePreviewWindow(QWidget *parent, ADM_coreVideoFilter *videoStream) : QDialog(parent)
 {
     ui.setupUi(this);
 
@@ -33,7 +33,6 @@ Ui_seekablePreviewWindow::Ui_seekablePreviewWindow(QWidget *parent, ADM_coreVide
     resetVideoStream(videoStream);
 
     seekablePreview->addControl(ui.toolLayout);
-    seekablePreview->sliderSet(defaultFrame);
     seekablePreview->sliderChanged();
 
     connect(ui.horizontalSlider, SIGNAL(valueChanged(int)), this, SLOT(sliderChanged(int)));

--- a/avidemux/qt4/ADM_userInterfaces/ADM_filters/Q_seekablePreview.h
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_filters/Q_seekablePreview.h
@@ -34,7 +34,7 @@ public:
 	Ui_seekablePreviewDialog ui;
         
 public:        
-                Ui_seekablePreviewWindow(QWidget *parent, ADM_coreVideoFilter *videoStream, uint32_t defaultFrame = 0);
+                Ui_seekablePreviewWindow(QWidget *parent, ADM_coreVideoFilter *videoStream);
                 ~Ui_seekablePreviewWindow();
 	void    resetVideoStream(ADM_coreVideoFilter *videoStream);
 	uint32_t frameIndex();

--- a/avidemux_core/ADM_coreVideoFilter/include/ADM_coreVideoFilter.h
+++ b/avidemux_core/ADM_coreVideoFilter/include/ADM_coreVideoFilter.h
@@ -47,6 +47,8 @@ typedef struct
     uint32_t timeBaseDen; // timebase denominator
     uint32_t timeBaseNum; // timebase numerator
     uint64_t totalDuration;     /// Duration of the whole stream in us
+    uint64_t markerA;
+    uint64_t markerB;
 }FilterInfo;
 
 /**

--- a/avidemux_core/ADM_coreVideoFilter/src/ADM_videoFilterBridge.cpp
+++ b/avidemux_core/ADM_coreVideoFilter/src/ADM_videoFilterBridge.cpp
@@ -48,6 +48,9 @@ ADM_videoFilterBridge::ADM_videoFilterBridge(IEditor *editor, uint64_t startTime
     bridgeInfo.frameIncrement = editor->getFrameIncrement();
     editor->getTimeBase(&(bridgeInfo.timeBaseNum), &(bridgeInfo.timeBaseDen));
     bridgeInfo.totalDuration = endTime - startTime;
+    bridgeInfo.markerA = editor->getMarkerAPts();
+    bridgeInfo.markerB = editor->getMarkerBPts();
+    
     rewind();
 }
 

--- a/avidemux_plugins/ADM_videoFilters6/blend/ADM_vidBlendFrames.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/blend/ADM_vidBlendFrames.cpp
@@ -63,6 +63,8 @@ bool AVDM_BlendFrames::configure()
   diaElem *elems[1]={&N};
   if(diaFactoryRun(QT_TRANSLATE_NOOP("blend","Blend"),1,elems)){
     info.totalDuration=previousFilter->getInfo()->totalDuration/((uint64_t)param.N);//This bad boy reports the proper duration to the loading bar
+    info.markerA=previousFilter->getInfo()->markerA/((uint64_t)param.N);
+    info.markerB=previousFilter->getInfo()->markerB/((uint64_t)param.N);
     return 1;
   }else
     return 0;
@@ -93,6 +95,8 @@ AVDM_BlendFrames::AVDM_BlendFrames(ADM_coreVideoFilter *in,CONFcouple *setup) : 
     accumulated=0;
     buffer=NULL;
     info.totalDuration=previousFilter->getInfo()->totalDuration/((uint64_t)param.N);
+    info.markerA=previousFilter->getInfo()->markerA/((uint64_t)param.N);
+    info.markerB=previousFilter->getInfo()->markerB/((uint64_t)param.N);
 }
 /**
  * \fn setCoupledConf

--- a/avidemux_plugins/ADM_videoFilters6/changeFps/changeFps.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/changeFps/changeFps.cpp
@@ -192,6 +192,20 @@ bool changeFps::updateTimingInfo(void)
     timing/=configuration.oldFpsDen;
     info.totalDuration=(uint64_t)timing;
 
+    timing=previousFilter->getInfo()->markerA;
+    timing*=configuration.oldFpsNum;
+    timing*=configuration.newFpsDen;
+    timing/=configuration.newFpsNum;
+    timing/=configuration.oldFpsDen;
+    info.markerA=(uint64_t)timing;
+
+    timing=previousFilter->getInfo()->markerB;
+    timing*=configuration.oldFpsNum;
+    timing*=configuration.newFpsDen;
+    timing/=configuration.newFpsNum;
+    timing/=configuration.oldFpsDen;
+    info.markerB=(uint64_t)timing;
+
     // 3 update timebase
     info.timeBaseDen=configuration.newFpsNum;
     info.timeBaseNum=configuration.newFpsDen;

--- a/avidemux_plugins/ADM_videoFilters6/dgBob/ADM_vidDGbob.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/dgBob/ADM_vidDGbob.cpp
@@ -138,6 +138,8 @@ void DGbob::update(void)
             break;
         case 2:
             info.totalDuration*=2;
+            info.markerA *= 2;
+            info.markerB *= 2;
             break;
         default: ADM_assert(0);
     }

--- a/avidemux_plugins/ADM_videoFilters6/stillimage/stillimage.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/stillimage/stillimage.cpp
@@ -231,6 +231,11 @@ bool stillimage::updateTimingInfo(void)
     }
 
     info.totalDuration=old+end-begin;
+    if (info.markerA >= begin)
+        info.markerA += end-begin;
+    if (info.markerB >= begin)
+        info.markerB += end-begin;
+
     return true;
 }
 


### PR DESCRIPTION
Makes marker info available for the filters.
Those filters, that change duration, also adjust the marker infos.
Partial filter overwrite marker infos with start stop times, if the son filter opened for configuration.
_The main goal here:_
Filter dialog seeks to markerA upon opening the filter for configuration. Also this means in case of partial filter, it seeks to the start time of the partial filter (regardless of actual editor marker positions).
With the current infrastructure, the seek is only to a key frame. 