### PR TITLE
[ADM_flyDialogRgb] improve performance

### DIFF
--- a/avidemux/qt4/ADM_UIs/include/DIA_flyDialogQt4.h
+++ b/avidemux/qt4/ADM_UIs/include/DIA_flyDialogQt4.h
@@ -40,6 +40,7 @@
 #include "ADM_coreVideoFilter.h"
 #include "ADM_imageResizer.h"
 #define ADM_FLY_SLIDER_MAX 1000
+#define ADM_FLYRGB_ALGO_CHANGE_THRESHOLD_RESOLUTION 720
 
 enum ResizeMethod 
 {

--- a/avidemux/qt4/ADM_UIs/include/DIA_flyDialogQt4.h
+++ b/avidemux/qt4/ADM_UIs/include/DIA_flyDialogQt4.h
@@ -195,6 +195,9 @@ public:
 class ADM_UIQT46_EXPORT ADM_flyDialogRgb: public  ADM_flyDialog
 {
   Q_OBJECT
+protected:
+                    ADMColorScaler_algo _algo;
+                    uint64_t           _scaledPts;
 public:
                     ADM_byteBuffer     _rgbByteBuffer;
                     ADM_byteBuffer     _rgbByteBufferOut;

--- a/avidemux/qt4/ADM_UIs/src/DIA_flyDialog.cpp
+++ b/avidemux/qt4/ADM_UIs/src/DIA_flyDialog.cpp
@@ -493,10 +493,16 @@ ADM_flyDialogRgb::ADM_flyDialogRgb(QDialog *parent,uint32_t width, uint32_t heig
 {
     uint32_t size = ADM_IMAGE_ALIGN(_w*4);
     size*=_h;
+    _scaledPts = -1LL;
     _rgbByteBuffer.setSize(size);
     _rgbByteBufferOut.setSize(size);
-     yuv2rgb =new ADMColorScalerSimple(_w,_h,ADM_COLOR_YV12,
-                toRgbColor());
+    _algo = ((_h > 720) ? ADM_CS_FAST_BILINEAR : ADM_CS_BICUBIC);
+     yuv2rgb =  new ADMColorScalerFull(_algo, 
+                            _w,
+                            _h,
+                            _w,
+                            _h,
+                            ADM_COLOR_YV12,toRgbColor());
     rgb2rgb=NULL;
     initializeSize();
     updateZoom();
@@ -506,7 +512,7 @@ ADM_flyDialogRgb::ADM_flyDialogRgb(QDialog *parent,uint32_t width, uint32_t heig
 void ADM_flyDialogRgb::resetScaler(void)
 {
     if(rgb2rgb) delete rgb2rgb;
-    rgb2rgb=new ADMColorScalerFull(ADM_CS_BICUBIC, 
+    rgb2rgb=new ADMColorScalerFull(_algo, 
                             _w,
                             _h,
                             _zoomW,
@@ -532,7 +538,11 @@ bool ADM_flyDialogRgb::process(void)
     {
         yuv2rgb->convertImage(_yuvBuffer,_rgbByteBufferDisplay.at(0));
     } else {
-        yuv2rgb->convertImage(_yuvBuffer,_rgbByteBuffer.at(0));
+        if (_scaledPts != lastPts)
+        {
+            yuv2rgb->convertImage(_yuvBuffer,_rgbByteBuffer.at(0));
+            _scaledPts = lastPts;
+        }
         if (_resizeMethod != RESIZE_NONE)
         {
             processRgb(_rgbByteBuffer.at(0),_rgbByteBufferOut.at(0));

--- a/avidemux/qt4/ADM_UIs/src/DIA_flyDialog.cpp
+++ b/avidemux/qt4/ADM_UIs/src/DIA_flyDialog.cpp
@@ -493,10 +493,10 @@ ADM_flyDialogRgb::ADM_flyDialogRgb(QDialog *parent,uint32_t width, uint32_t heig
 {
     uint32_t size = ADM_IMAGE_ALIGN(_w*4);
     size*=_h;
-    _scaledPts = -1LL;
+    _scaledPts = ADM_NO_PTS;
     _rgbByteBuffer.setSize(size);
     _rgbByteBufferOut.setSize(size);
-    _algo = ((_h > 720) ? ADM_CS_FAST_BILINEAR : ADM_CS_BICUBIC);
+    _algo = ((_h > ADM_FLYRGB_ALGO_CHANGE_THRESHOLD_RESOLUTION) ? ADM_CS_FAST_BILINEAR : ADM_CS_BICUBIC);
      yuv2rgb =  new ADMColorScalerFull(_algo, 
                             _w,
                             _h,


### PR DESCRIPTION
Resizing or dragging the rubber band in the Crop filter is sluggish at 1080p and even more above.
Therefore i improved on ADM_flyDialogRgb (ADM_flyDialogRgb used only by Crop and Blacken border):
- YUV->RGB conversion is performed only when necessary (Pts of the current image changed)
- above 720p scaling is ADM_CS_FAST_BILINEAR instead of ADM_CS_BICUBIC