### PR TITLE
[PulseAudioSimple] add volume control

### DIFF
--- a/avidemux_plugins/ADM_audioDevices/PulseAudioSimple/ADM_devicePulseSimple.h
+++ b/avidemux_plugins/ADM_audioDevices/PulseAudioSimple/ADM_devicePulseSimple.h
@@ -21,13 +21,14 @@ class pulseSimpleAudioDevice : public audioDeviceThreaded
      protected :
                      void    *instance;
                      uint32_t latency;
+                     int32_t  volumeHack;
          virtual     bool     localInit(void);
          virtual     bool     localStop(void);
          virtual     void     sendData(void); 
          virtual const CHANNEL_TYPE *getWantedChannelMapping(uint32_t channels);
       public:
                 pulseSimpleAudioDevice(void);
-                bool     hasVolumeControl(void) { return false; }
+                virtual     uint8_t setVolume(int volume);
                 uint32_t getLatencyMs(void);
      }     ;
 #endif


### PR DESCRIPTION
It's a dirty hack, as PulseAudioSimple API does not provides volume control.

OT: Alsa mixer volume control not working on my system, it has only multiple "IEC958" instances, neither "PCM" nor "Master".