### PR TITLE
[resampleFps] add motion compensated interpolation option

### DIFF
--- a/avidemux_plugins/ADM_videoFilters6/resampleFps/CMakeLists.txt
+++ b/avidemux_plugins/ADM_videoFilters6/resampleFps/CMakeLists.txt
@@ -1,15 +1,16 @@
 INCLUDE(vf_plugin)
 
-set(THREADS_PREFER_PTHREAD_FLAG TRUE)
-
 SET(ADM_vf_resampleFps_SRCS ADM_vidResampleFPS.cpp motin.cpp)
 
+IF(DO_COMMON)
+    include(admCheckThreads)
+ENDIF(DO_COMMON)
 
-#ADD_VIDEO_FILTER(ADM_vf_resampleFps ${ADM_vf_resampleFps_SRCS})
-
-ADD_LIBRARY(ADM_vf_resampleFps SHARED ${ADM_vf_resampleFps_SRCS})
-INCLUDE(vf_plugin)
-
+ADD_VIDEO_FILTER(ADM_vf_resampleFps ${ADM_vf_resampleFps_SRCS})
 INIT_VIDEO_FILTER(ADM_vf_resampleFps)
 INSTALL_VIDEO_FILTER(ADM_vf_resampleFps)
-ADD_TARGET_CFLAGS(ADM_vf_resampleFps "-I${AVIDEMUX_SOURCE_DIR}/avidemux_plugins")
+
+IF(DO_COMMON)
+    ADM_LINK_THREAD(ADM_vf_resampleFps)
+ENDIF(DO_COMMON)
+

--- a/avidemux_plugins/ADM_videoFilters6/resampleFps/CMakeLists.txt
+++ b/avidemux_plugins/ADM_videoFilters6/resampleFps/CMakeLists.txt
@@ -1,8 +1,15 @@
 INCLUDE(vf_plugin)
 
-SET(ADM_vf_resampleFps_SRCS ADM_vidResampleFPS.cpp)
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 
-ADD_VIDEO_FILTER(ADM_vf_resampleFps ${ADM_vf_resampleFps_SRCS})
+SET(ADM_vf_resampleFps_SRCS ADM_vidResampleFPS.cpp motin.cpp)
+
+
+#ADD_VIDEO_FILTER(ADM_vf_resampleFps ${ADM_vf_resampleFps_SRCS})
+
+ADD_LIBRARY(ADM_vf_resampleFps SHARED ${ADM_vf_resampleFps_SRCS})
+INCLUDE(vf_plugin)
 
 INIT_VIDEO_FILTER(ADM_vf_resampleFps)
 INSTALL_VIDEO_FILTER(ADM_vf_resampleFps)
+ADD_TARGET_CFLAGS(ADM_vf_resampleFps "-I${AVIDEMUX_SOURCE_DIR}/avidemux_plugins")

--- a/avidemux_plugins/ADM_videoFilters6/resampleFps/confResampleFps.conf
+++ b/avidemux_plugins/ADM_videoFilters6/resampleFps/confResampleFps.conf
@@ -2,5 +2,5 @@ confResampleFps{
 uint32_t:mode
 uint32_t:newFpsDen
 uint32_t:newFpsNum
-bool:blend
+uint32_t:interpolation
 }

--- a/avidemux_plugins/ADM_videoFilters6/resampleFps/confResampleFps.h
+++ b/avidemux_plugins/ADM_videoFilters6/resampleFps/confResampleFps.h
@@ -5,5 +5,5 @@ typedef struct {
 uint32_t mode;
 uint32_t newFpsDen;
 uint32_t newFpsNum;
-bool blend;
+uint32_t interpolation;
 }confResampleFps;

--- a/avidemux_plugins/ADM_videoFilters6/resampleFps/confResampleFps_desc.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/resampleFps/confResampleFps_desc.cpp
@@ -3,6 +3,6 @@ extern const ADM_paramList confResampleFps_param[]={
  {"mode",offsetof(confResampleFps,mode),"uint32_t",ADM_param_uint32_t},
  {"newFpsDen",offsetof(confResampleFps,newFpsDen),"uint32_t",ADM_param_uint32_t},
  {"newFpsNum",offsetof(confResampleFps,newFpsNum),"uint32_t",ADM_param_uint32_t},
- {"blend",offsetof(confResampleFps,blend),"bool",ADM_param_bool},
+ {"interpolation",offsetof(confResampleFps,interpolation),"uint32_t",ADM_param_uint32_t},
 {NULL,0,NULL}
 };

--- a/avidemux_plugins/ADM_videoFilters6/resampleFps/confResampleFps_json.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/resampleFps/confResampleFps_json.cpp
@@ -8,7 +8,7 @@ admJson json;
 json.addUint32("mode",key->mode);
 json.addUint32("newFpsDen",key->newFpsDen);
 json.addUint32("newFpsNum",key->newFpsNum);
-json.addBool("blend",key->blend);
+json.addUint32("interpolation",key->interpolation);
 return json.dumpToFile(file);
 };
 bool  confResampleFps_jdeserialize(const char *file, const ADM_paramList *tmpl,confResampleFps *key){

--- a/avidemux_plugins/ADM_videoFilters6/resampleFps/motin.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/resampleFps/motin.cpp
@@ -58,11 +58,7 @@ motin::motin(int width, int height)
     
     pyramidLevels = lv;
     
-    threads = 1;
-    if(false == prefs->get(FEATURES_THREADING_LAVC, &threads))
-        threads = 1;
-    if(!threads)
-        threads = ADM_cpu_num_processors();
+    threads = ADM_cpu_num_processors();
     threads /= 2;
     if (threads < 1)
         threads = 1;

--- a/avidemux_plugins/ADM_videoFilters6/resampleFps/motin.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/resampleFps/motin.cpp
@@ -40,7 +40,7 @@ motin::motin(int width, int height)
     do {
         pw = wp;
         ph = hp;
-        if ((wp < 128) || (hp < 128))
+        if ((wp < 32) || (hp < 32))
             break;
         pyramidA[lv] = new ADMImageDefault(wp, hp);
         pyramidB[lv] = new ADMImageDefault(wp, hp);

--- a/avidemux_plugins/ADM_videoFilters6/resampleFps/motin.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/resampleFps/motin.cpp
@@ -1,0 +1,596 @@
+/***************************************************************************
+                          Motion interpolation
+        Copyright 2021 szlldm
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "motin.h"
+#include <pthread.h>
+
+#if defined( ADM_CPU_X86) && !defined(_MSC_VER)
+        #define CAN_DO_INLINE_X86_ASM
+#endif
+
+motin::motin(int width, int height)
+{
+    frameW = width;
+    frameH = height;
+    frameA = new ADMImageDefault(width, height);
+    frameB = new ADMImageDefault(width, height);
+    pyramidA = new ADMImage* [MOTIN_MAX_PYRAMID_LEVELS];
+    pyramidB = new ADMImage* [MOTIN_MAX_PYRAMID_LEVELS];
+    pyramidWA = new ADMImage* [MOTIN_MAX_PYRAMID_LEVELS];
+    pyramidWB = new ADMImage* [MOTIN_MAX_PYRAMID_LEVELS];
+    upScalers   = new ADMColorScalerFull* [MOTIN_MAX_PYRAMID_LEVELS];
+    downScalers = new ADMColorScalerFull* [MOTIN_MAX_PYRAMID_LEVELS];
+    
+    int lv,wp,hp,pw,ph;
+    lv = 0;
+    wp = frameW;
+    hp = frameH;
+    do {
+        pw = wp;
+        ph = hp;
+        if ((wp < 128) || (hp < 128))
+            break;
+        pyramidA[lv] = new ADMImageDefault(wp, hp);
+        pyramidB[lv] = new ADMImageDefault(wp, hp);
+        pyramidWA[lv] = new ADMImageDefault(wp, hp);
+        pyramidWB[lv] = new ADMImageDefault(wp, hp);
+        
+        wp = ((wp /4) * 2);
+        hp = ((hp /4) * 2);
+        upScalers[lv] = new ADMColorScalerFull(ADM_CS_BICUBIC,pw,ph,wp,hp,ADM_COLOR_YV12,ADM_COLOR_YV12);
+        downScalers[lv] = new ADMColorScalerFull(ADM_CS_BICUBIC,wp,hp,pw,ph,ADM_COLOR_YV12,ADM_COLOR_YV12);
+        lv += 1;
+        if (lv >= MOTIN_MAX_PYRAMID_LEVELS)
+            break;
+    } while(1);
+    
+    pyramidLevels = lv;
+}
+
+
+motin::~motin()
+{
+    delete frameA;
+    delete frameB;
+
+    for (int lv=0; lv<pyramidLevels; lv++)
+    {
+        delete upScalers[lv];
+        delete downScalers[lv];
+        delete pyramidA[lv];
+        delete pyramidB[lv];
+        delete pyramidWA[lv];
+        delete pyramidWB[lv];
+    }
+    
+    
+    delete [] upScalers;
+    delete [] downScalers;
+    delete [] pyramidA;
+    delete [] pyramidB;
+    delete [] pyramidWA;
+    delete [] pyramidWB;
+}
+
+
+void motin::createPyramids(ADMImage * imgA, ADMImage * imgB)
+{
+    if (pyramidLevels < 1)
+        return;
+    frameA->duplicateFull(imgA);
+    frameB->duplicateFull(imgB);
+    pyramidA[0]->duplicateFull(imgA);
+    pyramidB[0]->duplicateFull(imgB);
+    
+    for (int lv=0; lv<(pyramidLevels-1); lv++)
+    {
+        upScalers[lv]->convertImage(pyramidA[lv], pyramidA[lv+1]);
+        upScalers[lv]->convertImage(pyramidB[lv], pyramidB[lv+1]);
+    }
+}
+
+int motin::sad(uint8_t * p1, uint8_t * p2, int stride, int x1, int y1, int x2, int y2)
+{
+    volatile int tmp = 0;
+    unsigned int a,b,i,j;
+    uint8_t * ptrb1, * ptrb2, * ptr1, * ptr2;
+
+    x1 -= 3;
+    y1 -= 3;
+    x2 -= 3;
+    y2 -= 3;
+    
+    ptrb1 = p1 + x1 + y1*stride;
+    ptrb2 = p2 + x2 + y2*stride;
+    
+#ifdef CAN_DO_INLINE_X86_ASM
+ if(CpuCaps::hasMMX())
+ {
+    __asm__(
+    ADM_ASM_ALIGN16
+    "pxor %%mm7,%%mm7\n"
+    ::);
+    
+    uint8_t * ptrb3, * ptrb4;
+    ptrb3 = ptrb1 + stride;
+    ptrb4 = ptrb2 + stride;
+
+    for (j=0; j<4; j++)
+    {
+        __asm__(
+        ADM_ASM_ALIGN16
+        "movq (%0),%%mm0 \n"
+        "movq (%1),%%mm1 \n"
+        "psadbw %%mm1,%%mm0\n"
+        "movq (%2),%%mm2 \n"
+        "movq (%3),%%mm3 \n"
+        "psadbw %%mm3,%%mm2\n"
+        "paddd %%mm0,%%mm7 \n"
+        "paddd %%mm2,%%mm7 \n"
+        : : "r" (ptrb1) , "r" (ptrb2) , "r" (ptrb3) , "r" (ptrb4)
+        );
+        ptrb1 += stride*2;
+        ptrb2 += stride*2;
+        ptrb3 += stride*2;
+        ptrb4 += stride*2;
+    }
+    
+    __asm__(
+    ADM_ASM_ALIGN16
+    "movd %%mm7,(%0)\n"
+    "emms \n"
+    :: "r" (&tmp)
+    );
+ }
+ else
+#endif 
+ {
+    for (j=0; j<8; j++)
+    {
+            ptr1 = ptrb1;
+            ptr2 = ptrb2;
+            ptrb1 += stride;
+            ptrb2 += stride;
+        //for (i=0; i<8; i++)
+        //{ unroll ->
+            a = *ptr1++;
+            b = *ptr2++;
+            tmp += abs((int)a - (int)b);
+            a = *ptr1++;
+            b = *ptr2++;
+            tmp += abs((int)a - (int)b);
+            a = *ptr1++;
+            b = *ptr2++;
+            tmp += abs((int)a - (int)b);
+            a = *ptr1++;
+            b = *ptr2++;
+            tmp += abs((int)a - (int)b);
+            a = *ptr1++;
+            b = *ptr2++;
+            tmp += abs((int)a - (int)b);
+            a = *ptr1++;
+            b = *ptr2++;
+            tmp += abs((int)a - (int)b);
+            a = *ptr1++;
+            b = *ptr2++;
+            tmp += abs((int)a - (int)b);
+            a = *ptr1++;
+            b = *ptr2++;
+            tmp += abs((int)a - (int)b);
+        //}
+    }
+ }
+    return tmp;
+}
+
+
+void *motin::worker_thread( void *ptr )
+{
+    worker_thread_arg * arg = (worker_thread_arg*)ptr;
+    int lv = arg->lv;
+    uint8_t ** plA = arg->plA;
+    uint8_t ** plB = arg->plB;
+    uint8_t ** plW = arg->plW;
+    int * strides = arg->strides;
+    uint32_t w = arg->w;
+    uint32_t h = arg->h;
+    int x,y,bx,by;
+
+
+    for (y=0; y<h; y++)
+        memset(plW[0]+y*strides[0], 128, w);
+    
+    w /= 2;
+    h /= 2;
+    
+    for (y=0; y<h; y++)
+    {
+        for (x=0; x<w; x++)
+        {
+            int initX = (unsigned int)plW[1][y*strides[1]+x];
+            int initY = (unsigned int)plW[2][y*strides[2]+x];
+            initX -= 128;
+            initY -= 128;
+            initX *= 2;
+            initY *= 2;
+            initX += x*2;
+            initY += y*2;
+            
+            if ((initX < 0+3) || (initX >= w*2-1-3) || (initY < 0+3) || (initY >= h*2-1-3))
+            {
+                initX -= x*2;
+                initY -= y*2;
+                initX += 128;
+                initY += 128;
+                plW[1][y*strides[1]+x] = initX;
+                plW[2][y*strides[2]+x] = initY;
+                continue;
+            }
+            
+            int best[2];
+            best[0] = initX;
+            best[1] = initY;
+            int sad0 = sad(plA[0], plB[0], strides[0], x*2, y*2, initX, initY);
+            
+            int radius = MOTIN_SEARCH_RADIUS + lv/2;
+            for (by=(initY-radius);by<=(initY+radius);by++)
+            {
+                if (by < 0+3)
+                    continue;
+                if (by >= (h*2-1)-3)
+                    continue;
+                for (bx=(initX-radius);bx<=(initX+radius);bx++)
+                {
+                    if (bx < 0+3)
+                        continue;
+                    if (bx >= (w*2-1)-3)
+                        continue;
+                    if ((bx == initX) && (by == initY))
+                        continue;
+                    
+                    int sadc = sad(plA[0], plB[0], strides[0], x*2, y*2, bx, by);
+                    
+                    if (sadc < sad0)
+                    {
+                        sad0 = sadc;
+                        best[0] = bx;
+                        best[1] = by;
+                    }
+                }
+            }
+            
+            best[0] -= x*2;
+            best[1] -= y*2;
+            best[0] += 128;
+            best[1] += 128;
+            for (int bl=0; bl<2; bl++)
+            {
+                if (best[bl] < 16)
+                    best[bl] = 16;
+                if (best[bl] > 240)
+                    best[bl] = 240;
+            }
+            plW[1][y*strides[1]+x] = best[0];
+            plW[2][y*strides[2]+x] = best[1];
+        }
+    }
+
+    // spatial filter
+    for (y=0; y<h; y++)
+    {
+        for (x=0; x<w; x++)
+        {
+            unsigned int sumX, sumY, cnt;
+            sumX = 0;
+            sumY = 0;
+            cnt = 0;
+            for (by=y-2;by<=y+2;by++)
+            {
+                if (by < 0)
+                    continue;
+                if (by >= h)
+                    continue;
+                for (bx=x-2;bx<=x+2;bx++)
+                {
+                    if (bx < 0)
+                        continue;
+                    if (bx >= w)
+                        continue;
+                    sumX += plW[1][bx + by*strides[1]];
+                    sumY += plW[2][bx + by*strides[2]];
+                    cnt += 1;
+                }
+            }
+            sumX /= cnt;
+            sumY /= cnt;
+            plA[1][x + y*strides[1]] = sumX;
+            plA[2][x + y*strides[2]] = sumY;
+        }
+    }
+    for (y=0; y<h; y++)
+    {
+        for (x=0; x<w; x++)
+        {
+            plW[1][x + y*strides[1]] = plA[1][x + y*strides[1]];
+            plW[2][x + y*strides[2]] = plA[2][x + y*strides[2]];
+        }
+    }
+
+    pthread_exit(NULL);
+}
+    
+    
+void motin::estimateMotion()
+{
+    uint8_t * planes[3];
+    uint8_t * wplanes[3];
+    int strides[3];
+    uint32_t w,h;
+
+    pyramidWA[pyramidLevels-1]->getWidthHeight(&w,&h);
+    w /= 2;
+    h /= 2;
+    pyramidWA[pyramidLevels-1]->GetPitches(strides);
+
+    pyramidWA[pyramidLevels-1]->GetWritePlanes(wplanes);
+    for (int y = 0; y<h; y++)
+    {
+        memset(wplanes[1] + y*strides[1], 128, w);
+        memset(wplanes[2] + y*strides[2], 128, w);
+    }
+    pyramidWB[pyramidLevels-1]->GetWritePlanes(wplanes);
+    for (int y = 0; y<h; y++)
+    {
+        memset(wplanes[1] + y*strides[1], 128, w);
+        memset(wplanes[2] + y*strides[2], 128, w);
+    }
+
+
+    for (int lv=pyramidLevels-1; lv>=0; lv--)
+    {
+    
+        pthread_t thread1, thread2;
+        worker_thread_arg arg1, arg2;
+        
+        arg1.lv = lv;
+        pyramidA[lv]->GetWritePlanes(arg1.plA);
+        pyramidB[lv]->GetWritePlanes(arg1.plB);
+        pyramidWA[lv]->GetWritePlanes(arg1.plW);
+        pyramidA[lv]->GetPitches(arg1.strides);
+        pyramidA[lv]->getWidthHeight(&arg1.w, &arg1.h);
+        
+        arg2.lv = lv;
+        pyramidB[lv]->GetWritePlanes(arg2.plA);
+        pyramidA[lv]->GetWritePlanes(arg2.plB);
+        pyramidWB[lv]->GetWritePlanes(arg2.plW);
+        pyramidA[lv]->GetPitches(arg2.strides);
+        pyramidA[lv]->getWidthHeight(&arg2.w, &arg2.h);
+        
+        pthread_create( &thread1, NULL, worker_thread, (void*) &arg1);
+        pthread_create( &thread2, NULL, worker_thread, (void*) &arg2);
+        
+        // work in thread workers...
+        
+        pthread_join( thread1, NULL);
+        pthread_join( thread2, NULL); 
+        
+        // filter
+        {
+            int x,y,bx,by;
+            uint8_t * plA[3];
+            uint8_t * plB[3];
+            uint8_t * plW[3];
+            pyramidA[lv]->GetPitches(strides);
+            pyramidA[lv]->getWidthHeight(&w,&h);
+            w /= 2;
+            h /= 2;
+
+
+            // balance directional estimations
+            pyramidWA[lv]->GetWritePlanes(plA);
+            pyramidWB[lv]->GetWritePlanes(plB);
+            for (y=0; y<h; y++)
+            {
+                for (x=0; x<w; x++)
+                {
+                    int ax = (unsigned int)plA[1][y*strides[1]+x];
+                    int ay = (unsigned int)plA[2][y*strides[2]+x];
+                    int bx = (unsigned int)plB[1][y*strides[1]+x];
+                    int by = (unsigned int)plB[2][y*strides[2]+x];
+                    ax -= 128;
+                    ay -= 128;
+                    bx -= 128;
+                    by -= 128;
+                    ax -= bx;
+                    ay -= by;
+                    ax /= 2;
+                    ay /= 2;
+                    bx = -1*ax;
+                    by = -1*ay;
+                    ax += 128;
+                    ay += 128;
+                    bx += 128;
+                    by += 128;
+                    plA[1][y*strides[1]+x] = ax;
+                    plA[2][y*strides[2]+x] = ay;
+                    plB[1][y*strides[1]+x] = bx;
+                    plB[2][y*strides[2]+x] = by;
+                }
+            }
+        }
+        
+        
+        for (int dir=0; dir<2; dir++)
+        {
+            if (lv>0)
+            {
+                if (dir == 0)
+                {
+                    downScalers[lv-1]->convertImage(pyramidWA[lv], pyramidWA[lv-1]);
+                }
+                else 
+                {
+                    downScalers[lv-1]->convertImage(pyramidWB[lv], pyramidWB[lv-1]);
+                }
+            }
+        }
+    }
+
+}
+
+
+void motin::interpolate(ADMImage * dst, int alpha)
+{
+    if (alpha > 256)
+        alpha = 256;
+        
+    int w,h,x,y,p,alphao;
+    
+    uint8_t * dplanes[3];
+    uint8_t * wplanes[3];
+    uint8_t * pplanes[3];
+    int dstrides[3];
+    int wstrides[3];
+    int pstrides[3];
+
+    dst->GetPitches(dstrides);
+    dst->GetWritePlanes(dplanes);
+
+    pyramidWA[0]->GetPitches(wstrides);
+    pyramidWA[0]->GetWritePlanes(wplanes);
+    frameA->GetPitches(pstrides);
+    frameA->GetWritePlanes(pplanes);
+
+    for (y=0; y<frameH; y++)
+    {
+        for (x=0; x<frameW; x++)
+        {
+            int mx,my;
+            mx = (unsigned int)wplanes[1][x/2 + y/2*wstrides[1]];
+            my = (unsigned int)wplanes[2][x/2 + y/2*wstrides[2]];
+            mx -= 128;
+            my -= 128;
+            mx = (mx*alpha)/256;
+            my = (my*alpha)/256;
+            mx *= -1;
+            my *= -1;
+            mx += x;
+            my += y;
+            if ((mx < 0) || (mx >= frameW))
+                continue;
+            if ((my < 0) || (my >= frameH))
+                continue;
+            dplanes[0][x+y*dstrides[0]] = pplanes[0][mx+my*pstrides[0]];
+        }
+    }
+    
+    for (p=1; p<3; p++)
+    {
+        for (y=0; y<frameH/2; y++)
+        {
+            for (x=0; x<frameW/2; x++)
+            {
+                int mx,my;
+                mx = (unsigned int)wplanes[1][x + y*wstrides[1]];
+                my = (unsigned int)wplanes[2][x + y*wstrides[2]];
+                mx -= 128;
+                my -= 128;
+                mx = (mx*alpha)/256;
+                my = (my*alpha)/256;
+                mx *= -1;
+                my *= -1;
+                mx /= 2;
+                my /= 2;
+                mx += x;
+                my += y;
+                if ((mx < 0) || (mx >= frameW/2))
+                    continue;
+                if ((my < 0) || (my >= frameH/2))
+                    continue;
+                dplanes[p][x+y*dstrides[p]] = pplanes[p][mx+my*pstrides[p]];
+            }
+        }
+    }
+
+    pyramidWB[0]->GetPitches(wstrides);
+    pyramidWB[0]->GetWritePlanes(wplanes);
+    frameB->GetPitches(pstrides);
+    frameB->GetWritePlanes(pplanes);
+    alphao = alpha;
+    alpha = 256-alpha;
+
+    for (y=0; y<frameH; y++)
+    {
+        for (x=0; x<frameW; x++)
+        {
+            int mx,my;
+            mx = (unsigned int)wplanes[1][x/2 + y/2*wstrides[1]];
+            my = (unsigned int)wplanes[2][x/2 + y/2*wstrides[2]];
+            mx -= 128;
+            my -= 128;
+            mx = (mx*alpha)/256;
+            my = (my*alpha)/256;
+            mx *= -1;
+            my *= -1;
+            mx += x;
+            my += y;
+            if ((mx < 0) || (mx >= frameW))
+                continue;
+            if ((my < 0) || (my >= frameH))
+                continue;
+            int px = dplanes[0][x+y*dstrides[0]];
+            px *= alpha;
+            px += ((unsigned int)pplanes[0][mx+my*pstrides[0]])*alphao;
+            dplanes[0][x+y*dstrides[0]] = px/(256);
+        }
+    }
+    
+    for (p=1; p<3; p++)
+    {
+        for (y=0; y<frameH/2; y++)
+        {
+            for (x=0; x<frameW/2; x++)
+            {
+                int mx,my;
+                mx = (unsigned int)wplanes[1][x + y*wstrides[1]];
+                my = (unsigned int)wplanes[2][x + y*wstrides[2]];
+                mx -= 128;
+                my -= 128;
+                mx = (mx*alpha)/256;
+                my = (my*alpha)/256;
+                mx *= -1;
+                my *= -1;
+                mx /= 2;
+                my /= 2;
+                mx += x;
+                my += y;
+                if ((mx < 0) || (mx >= frameW/2))
+                    continue;
+                if ((my < 0) || (my >= frameH/2))
+                    continue;
+                int px = dplanes[p][x+y*dstrides[p]];
+                px *= alpha;
+                px += ((unsigned int)pplanes[p][mx+my*pstrides[p]])*alphao;
+                dplanes[p][x+y*dstrides[p]] = px/(256);
+            }
+        }
+    }
+
+    /*pyramidWA[0]->copyPlane(pyramidWA[0], dst, (ADM_PLANE)0);
+
+    pyramidWA[0]->copyPlane(pyramidWA[0], dst, (ADM_PLANE)1);
+    pyramidWA[0]->copyPlane(pyramidWA[0], dst, (ADM_PLANE)2);*/
+}
+
+

--- a/avidemux_plugins/ADM_videoFilters6/resampleFps/motin.h
+++ b/avidemux_plugins/ADM_videoFilters6/resampleFps/motin.h
@@ -28,6 +28,7 @@ class  motin
     uint32_t    threads;
     int         frameW, frameH;
     int         pyramidLevels;
+    bool        sceneChanged;
     ADMImage *  frameA;
     ADMImage *  frameB;
     ADMImage ** pyramidA;

--- a/avidemux_plugins/ADM_videoFilters6/resampleFps/motin.h
+++ b/avidemux_plugins/ADM_videoFilters6/resampleFps/motin.h
@@ -14,7 +14,7 @@
  
 #pragma once
 
-#include <cmath>
+#include <pthread.h>
 #include "ADM_image.h"
 #include "ADM_default.h"
 
@@ -25,6 +25,7 @@ class  motin
 {
 
   protected:
+    uint32_t    threads;
     int         frameW, frameH;
     int         pyramidLevels;
     ADMImage *  frameA;
@@ -43,9 +44,16 @@ class  motin
         uint8_t * plW[3];
         int strides[3];
         uint32_t w,h;
+        uint32_t ystart, yincr;
     } worker_thread_arg;
     
-    static void *worker_thread( void *ptr );
+    pthread_t  * me_threads1;
+    pthread_t  * me_threads2;
+    worker_thread_arg * worker_thread_args1;
+    worker_thread_arg * worker_thread_args2;
+    
+    static void *me_worker_thread( void *ptr );
+    static void *spf_worker_thread( void *ptr );
     
     static int sad(uint8_t * p1, uint8_t * p2, int stride, int x1, int y1, int x2, int y2);
 

--- a/avidemux_plugins/ADM_videoFilters6/resampleFps/motin.h
+++ b/avidemux_plugins/ADM_videoFilters6/resampleFps/motin.h
@@ -35,8 +35,18 @@ class  motin
     ADMImage ** pyramidB;
     ADMImage ** pyramidWA;
     ADMImage ** pyramidWB;
-    ADMColorScalerFull ** upScalers;
+    ADMColorScalerFull ** upScalersA;
+    ADMColorScalerFull ** upScalersB;
     ADMColorScalerFull ** downScalers;
+    
+    typedef struct {
+        int levels;
+        ADMColorScalerFull ** scalers;
+        ADMImage ** src;
+        ADMImage ** dst;
+    } scaler_thread_arg;
+    
+    static void *scaler_thread( void *ptr );
     
     typedef struct {
         int lv;

--- a/avidemux_plugins/ADM_videoFilters6/resampleFps/motin.h
+++ b/avidemux_plugins/ADM_videoFilters6/resampleFps/motin.h
@@ -1,0 +1,59 @@
+/***************************************************************************
+                          Motion interpolation
+        Copyright 2021 szlldm
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+ 
+#pragma once
+
+#include <cmath>
+#include "ADM_image.h"
+#include "ADM_default.h"
+
+#define MOTIN_MAX_PYRAMID_LEVELS  (7)
+#define MOTIN_SEARCH_RADIUS       (2)
+
+class  motin
+{
+
+  protected:
+    int         frameW, frameH;
+    int         pyramidLevels;
+    ADMImage *  frameA;
+    ADMImage *  frameB;
+    ADMImage ** pyramidA;
+    ADMImage ** pyramidB;
+    ADMImage ** pyramidWA;
+    ADMImage ** pyramidWB;
+    ADMColorScalerFull ** upScalers;
+    ADMColorScalerFull ** downScalers;
+    
+    typedef struct {
+        int lv;
+        uint8_t * plA[3];
+        uint8_t * plB[3];
+        uint8_t * plW[3];
+        int strides[3];
+        uint32_t w,h;
+    } worker_thread_arg;
+    
+    static void *worker_thread( void *ptr );
+    
+    static int sad(uint8_t * p1, uint8_t * p2, int stride, int x1, int y1, int x2, int y2);
+
+  public:
+    motin(int width, int height);
+    ~motin();
+    
+    void createPyramids(ADMImage * imgA, ADMImage * imgB);
+    void estimateMotion();
+    void interpolate(ADMImage * dst, int alpha);
+};


### PR DESCRIPTION
its experimental / far from perfect, it does not handle large motion well...
it is significantly faster than ffmpeg's minterpolate, but quality lacks behind.
however, if there are no large motions (eg. 20fps->60fps, 30fps->60fps) it is better most of the time than the "Blend" interpolation.
so dont try 1..2..5 fps->60fps conversion :)
there is no scene change detection. visible artifacts can occur.
overall, its not bad for a two afternoon job :)

i dont know cmake at all, so it was a little struggle to make CMakeLists.txt work, i hope its okay in the current state.