### PR TITLE
[crop/qt5] fix autocrop

### DIFF
--- a/avidemux_plugins/ADM_videoFilters6/crop/qt5/DIA_flyCrop.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/crop/qt5/DIA_flyCrop.cpp
@@ -646,7 +646,7 @@ Ui_cropWindow::Ui_cropWindow(QWidget* parent, crop *param,ADM_coreVideoFilter *i
     connect(pushButtonReset,SIGNAL(clicked(bool)),this,SLOT(reset(bool)));
 
     const QString autorun = QT_TRANSLATE_NOOP("crop","Auto Crop");
-    pushButtonAutoCrop = ui.buttonBox->addButton(autorun,QDialogButtonBox::ResetRole);    // group together with the Reset button
+    pushButtonAutoCrop = ui.buttonBox->addButton(autorun,QDialogButtonBox::ActionRole);
     changeARSelect(param->ar_select); // may be called only after pushButtonAutoCrop has become valid
     connect(pushButtonAutoCrop,SIGNAL(clicked(bool)),this,SLOT(autoCrop(bool)));
 

--- a/avidemux_plugins/ADM_videoFilters6/crop/qt5/DIA_flyCrop.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/crop/qt5/DIA_flyCrop.cpp
@@ -18,8 +18,7 @@
 #include "./Q_crop.h"
 #include "ADM_toolkitQt.h"
 
-uint8_t Metrics( uint8_t *in, uint32_t width,uint32_t *avg, uint32_t *eqt);
-uint8_t MetricsV( uint8_t *in, uint32_t width,uint32_t height,uint32_t *avg, uint32_t *eqt);
+uint8_t Metrics( uint8_t *in, uint32_t stride, uint32_t length, uint32_t *avg, uint32_t *var, uint32_t * max);
 
 /**
  * 
@@ -378,38 +377,43 @@ bool flyCrop::blockChanges(bool block)
      \fn autoRun
     \brief 
 */
-#define THRESH_AVG   30
-#define THRESH_EQT   50
+#define THRESH_AVG   8
+#define THRESH_VAR   30
+#define THRESH_MAX   24
 
-int flyCrop::autoRun(uint8_t *in,int w,int h, int increment)
+int flyCrop::autoRun(uint8_t *in,int w,int h, int increment, int blackLevel)
 {
-    uint32_t avg,eqt;
+    uint32_t avg,var,max;
+    uint32_t prev_avg = 999;
     int y;
-    for(y=0;y<h;y++)	
+    for(y=0;y<h;y++)
     {
-        Metrics(in,w,&avg,&eqt);
-        in+=increment;
-        if(avg> THRESH_AVG || eqt > THRESH_EQT)
-                break;
+        Metrics(in, 1, w, &avg, &var, &max);
+        avg = ((avg <= blackLevel) ? 0 : avg - blackLevel);
+        max = ((max <= blackLevel) ? 0 : max - blackLevel);
+        in += increment;
+        if(avg > (prev_avg+2)*2 || avg> THRESH_AVG || var > THRESH_VAR || max > THRESH_MAX)
+            break;
+        prev_avg = avg;
     }
-    if(y)
-        y=y-1;
-    return y&0xfffe;
+    return y;
 }
-int flyCrop::autoRunV(uint8_t *in, int stride, int w, int increment)
+int flyCrop::autoRunV(uint8_t *in, int stride, int w, int increment, int blackLevel)
 {
-    uint32_t avg,eqt;
+    uint32_t avg,var,max;
+    uint32_t prev_avg = 999;
     int y;
     for(y=0;y<w;y++)
     {
-        MetricsV(in,stride,_h,&avg,&eqt);
-        in+=increment;
-        if(avg> THRESH_AVG || eqt > THRESH_EQT)
-                break;
+        Metrics(in, stride, _h, &avg, &var, &max);
+        avg = ((avg <= blackLevel) ? 0 : avg - blackLevel);
+        max = ((max <= blackLevel) ? 0 : max - blackLevel);
+        in += increment;
+        if(avg > (prev_avg+2)*2 || avg> THRESH_AVG || var > THRESH_VAR || max > THRESH_MAX)
+            break;
+        prev_avg = avg;
     }
-    if(y)
-        y=y-1;
-    return y&0xfffe;
+    return y;
 }
 /**
  * 
@@ -420,11 +424,28 @@ uint8_t  flyCrop::autocrop(void)
     uint8_t *in;
     in=_yuvBuffer->GetReadPtr(PLANAR_Y);
     int stride=_yuvBuffer->GetPitch(PLANAR_Y);
+    int blackLevel = 0;
+    if(_yuvBuffer->_range == ADM_COL_RANGE_MPEG)
+        blackLevel = 16;
 
-    top=autoRun(in,_w,((_h>>1)-2),stride);
-    bottom=autoRun(in+stride*(_h-1),_w,((_h>>1)-2),-stride);
-    left=autoRunV(in,stride,((_w>>1)-2),1);
-    right=autoRunV(in+_w-1,stride,((_w>>1)-2),-1);
+    top=autoRun(in,_w,((_h>>1)-2),stride, blackLevel);
+    bottom=autoRun(in+stride*(_h-1),_w,((_h>>1)-2),-stride, blackLevel);
+    left=autoRunV(in,stride,((_w>>1)-2),1, blackLevel);
+    right=autoRunV(in+_w-1,stride,((_w>>1)-2),-1, blackLevel);
+    if ((top & 1) ^ (bottom & 1))    // both must have the same parity
+    {
+        if (top < bottom)
+            top++;
+        else
+            bottom++;
+    }
+    if ((left & 1) ^ (right & 1))    // both must have the same parity
+    {
+        if (left < right)
+            left++;
+        else
+            right++;
+    }
     upload(false,true);
     sameImage();
     return 1;
@@ -625,7 +646,7 @@ Ui_cropWindow::Ui_cropWindow(QWidget* parent, crop *param,ADM_coreVideoFilter *i
     connect(pushButtonReset,SIGNAL(clicked(bool)),this,SLOT(reset(bool)));
 
     const QString autorun = QT_TRANSLATE_NOOP("crop","Auto Crop");
-    pushButtonAutoCrop = ui.buttonBox->addButton(autorun,QDialogButtonBox::ActionRole);
+    pushButtonAutoCrop = ui.buttonBox->addButton(autorun,QDialogButtonBox::ResetRole);    // group together with the Reset button
     changeARSelect(param->ar_select); // may be called only after pushButtonAutoCrop has become valid
     connect(pushButtonAutoCrop,SIGNAL(clicked(bool)),this,SLOT(autoCrop(bool)));
 

--- a/avidemux_plugins/ADM_videoFilters6/crop/qt5/DIA_flyCrop.h
+++ b/avidemux_plugins/ADM_videoFilters6/crop/qt5/DIA_flyCrop.h
@@ -13,8 +13,8 @@ class flyCrop : public ADM_flyDialogRgb
     int         _lw,_lh;
 
     void        dimensions();
-    int         autoRun(uint8_t *in,int w,int h, int increment);
-    int         autoRunV(uint8_t *in, int stride, int w, int increment);
+    int         autoRun(uint8_t *in,int w,int h, int increment, int blackLevel);
+    int         autoRunV(uint8_t *in, int stride, int w, int increment, int blackLevel);
 
 public:
     uint8_t     processRgb(uint8_t *imageIn, uint8_t *imageOut);

--- a/avidemux_plugins/ADM_videoFilters6/crop/qt5/Q_crop.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/crop/qt5/Q_crop.cpp
@@ -44,52 +44,34 @@ int DIA_getCropParams(	const char *name,crop *param,ADM_coreVideoFilter *in)
 
 /**
      \fn Metrics
-	\brief Compute the average value of pixels	and eqt is the "ecart type"
+	\brief Compute the average value, variance and maximum of pixels
 */
 
-uint8_t Metrics( uint8_t *in, uint32_t width,uint32_t *avg, uint32_t *eqt)
+uint8_t Metrics( uint8_t *in, uint32_t stride, uint32_t length, uint32_t *avg, uint32_t *var, uint32_t * max)
 {
-
-uint32_t x;
-uint32_t sum=0,eq=0;
-int v;
-              for(x=0;x<width;x++)
-              {
-                      sum+=*(in+x);
-              }
-              sum=sum/width;
-              *avg=sum;
-              for(x=0;x<width;x++)
-              {
-                      v=*(in+x)-sum;
-                      eq+=v*v;
-              }
-              eq=eq/(width*width);
-              *eqt=eq;
-              return 1;
-}
-/**
-     \fn MetricsV
-	\brief Compute the average value of pixels	and eqt is the "ecart type"
-*/
-uint8_t MetricsV( uint8_t *in,uint32_t width, uint32_t height,uint32_t *avg, uint32_t *eqt)
-{
-
-uint32_t x;
-uint32_t sum=0,eq=0;
-int v;
-    for(x=0;x<height;x++)
+    uint8_t * ptr;
+    uint32_t x;
+    uint32_t sum=0,eq=0,m=0;
+    int v;
+    ptr = in;
+    for(x=0; x<length; x++)
     {
-            sum+=*(in+x*width);
+        sum += *ptr;
+        if (m < *ptr)
+            m = *ptr;
+        ptr += stride;
     }
-    sum=sum/height;
-    *avg=sum;
-    for(x=0;x<height;x++)
+    sum /= length;
+    *avg = sum;
+    *max = m;
+    ptr = in;
+    for(x=0;x<length;x++)
     {
-            v=*(in+x*width)-sum;
-            eq+=v*v;
+        v = *ptr - sum;
+        eq += v*v;
+        ptr += stride;
     }
-    eq=eq/(height*height);
-    *eqt=eq;
+    eq /= length;
+    *var = eq;
     return 1;
 }


### PR DESCRIPTION
-works on darker scenes then before
-allow odd values (opposite pairs must have same parity)
-it can achieve perfect crops (no black borders left)
-changed ButtonRole of the Auto Crop button to ResetRole, so it is now groupped with the Reset button