### PR TITLE
[Q_gui2] filter navigation actions to prevent congestions

### DIFF
--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
@@ -458,6 +458,7 @@ MainWindow::MainWindow(const vector<IScriptEngine*>& scriptEngines) : _scriptEng
     dragState=dragState_Normal;
     recentFiles = NULL;
     recentProjects = NULL;
+    actionLock = 0;
 
 #if defined(__APPLE__) && defined(USE_SDL)
     //ui.actionAbout_avidemux->setMenuRole(QAction::NoRole);

--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.h
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.h
@@ -22,6 +22,7 @@
 
 #define ENABLE_EVENT_FILTER
 
+#define NAVIGATION_ACTION_LOCK_THRESHOLD	(4)
 /**
  * \class myQApplication
  * \brief make sure the checkCrash & friends are done after Qt init
@@ -136,6 +137,7 @@ protected:
     
     bool     refreshCapEnabled;
     uint32_t refreshCapValue;
+    unsigned int actionLock;
 
     std::vector<QAction *>ActionsAvailableWhenFileLoaded;
     std::vector<QAction *>ActionsDisabledOnPlayback;
@@ -194,13 +196,21 @@ public slots:
             setMenuItemsEnabledState();
             playing=1-playing;
         }
+        actionLock++;
         HandleAction(a);
+        actionLock--;
         setMenuItemsEnabledState();
     }
     void sendAction(Action a)
     {
-        //printf("Sending internal event %d\n",(int)a);
-        emit actionSignal(a);
+        if(a>ACT_NAVIGATE_BEGIN && a<ACT_NAVIGATE_END && a!=ACT_Scale)
+        {
+            if (actionLock<=NAVIGATION_ACTION_LOCK_THRESHOLD)
+                emit actionSignal(a);
+        } else {
+            //printf("Sending internal event %d\n",(int)a);
+            emit actionSignal(a);
+        }
     }
     void timeChanged(int);
     void checkChanged(int);


### PR DESCRIPTION
When i continuously press left/right key for navigation (for fine cutting this is inevitable), and the decoder cant keep up, there is a congestion in the action queue. Especially using left key, i can experience more than 10 seconds unresponsive time, when it just keeps going back after i have released the key, and goes way over the desired frame.