### PR TITLE
[Q_encoding] display output file name, option for delete temporary files

### DIFF
--- a/avidemux/cli/ADM_userInterfaces/ADM_dialog/DIA_encoding_none.h
+++ b/avidemux/cli/ADM_userInterfaces/ADM_dialog/DIA_encoding_none.h
@@ -50,6 +50,7 @@ public:
 
     
     void setPhasis(const char *n);
+    void setFileName(const char *n) {};
     void setAudioCodec(const char *n);
     void setVideoCodec(const char *n);
     void setBitrate(uint32_t br,uint32_t globalbr);

--- a/avidemux/cli/ADM_userInterfaces/ADM_dialog/DIA_encoding_none.h
+++ b/avidemux/cli/ADM_userInterfaces/ADM_dialog/DIA_encoding_none.h
@@ -51,6 +51,7 @@ public:
     
     void setPhasis(const char *n);
     void setFileName(const char *n) {};
+    void setFileName(const char *n, const char *l) {};
     void setAudioCodec(const char *n);
     void setVideoCodec(const char *n);
     void setBitrate(uint32_t br,uint32_t globalbr);

--- a/avidemux/common/gui_savenew.cpp
+++ b/avidemux/common/gui_savenew.cpp
@@ -206,6 +206,7 @@ bool abort=false;
             return NULL;
         }
         muxer->createUI(videoDuration);
+        muxer->getEncoding()->setFileName(fileName.c_str());
         muxer->getEncoding()->setPhasis("Pass 1"); // don't make it translatable here, this is done in the encoding dialog
 
         ADMBitstream bitstream;

--- a/avidemux/common/gui_savenew.cpp
+++ b/avidemux/common/gui_savenew.cpp
@@ -117,7 +117,7 @@ int A_Save(const char *name)
         }
         fileName=std::string(out);
         logFileName=fileName;
-        logFileName+=std::string(".stats");
+        logFileName+=std::string(ADM_2PASS_STATS_FILE_EXTENSION);
         muxer=NULL;
         chain=NULL;
         audio=NULL;

--- a/avidemux/common/gui_savenew.cpp
+++ b/avidemux/common/gui_savenew.cpp
@@ -117,6 +117,8 @@ int A_Save(const char *name)
         }
         fileName=std::string(out);
         logFileName=fileName;
+        logFileName+=std::string(".");
+        logFileName+=std::string(videoEncoder6_GetCurrentEncoderName());
         logFileName+=std::string(ADM_2PASS_STATS_FILE_EXTENSION);
         muxer=NULL;
         chain=NULL;
@@ -206,7 +208,7 @@ bool abort=false;
             return NULL;
         }
         muxer->createUI(videoDuration);
-        muxer->getEncoding()->setFileName(fileName.c_str());
+        muxer->getEncoding()->setFileName(fileName.c_str(), logFileName.c_str());
         muxer->getEncoding()->setPhasis("Pass 1"); // don't make it translatable here, this is done in the encoding dialog
 
         ADMBitstream bitstream;

--- a/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_encoding.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_encoding.cpp
@@ -205,6 +205,9 @@ DIA_encodingQt4::~DIA_encodingQt4( )
         if(!ADM_shutdown())
             ADM_warning("Shutdown request failed\n");
     }
+    if (outputFileName)
+        ADM_dezalloc(outputFileName);
+    outputFileName=NULL;
 }
 /**
     \fn setPhasis(const char *n)

--- a/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_encoding.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_encoding.cpp
@@ -108,12 +108,18 @@ void DIA_encodingQt4::keepOpenChanged(int state)
 #endif
 }
 
+void DIA_encodingQt4::deleteStatsChanged(int state)
+{
+    deleteStats=!!state;
+}
+
 static char stringMe[80];
 
 DIA_encodingQt4::DIA_encodingQt4(uint64_t duration) : DIA_encodingBase(duration)
 {
         stopRequest=false;
         stayOpen=false;
+        deleteStats=false;
         firstPass=false;
         UI_getTaskBarProgress()->enable();
         ui=new Ui_encodingDialog;
@@ -135,6 +141,7 @@ DIA_encodingQt4::DIA_encodingQt4(uint64_t duration) : DIA_encodingBase(duration)
 #endif
 	connect(ui->checkBoxShutdown, SIGNAL(stateChanged(int)), this, SLOT(shutdownChanged(int)));
 	connect(ui->checkBoxKeepOpen, SIGNAL(stateChanged(int)), this, SLOT(keepOpenChanged(int)));
+	connect(ui->checkBoxDeleteStats, SIGNAL(stateChanged(int)), this, SLOT(deleteStatsChanged(int)));
 	connect(ui->pushButton1, SIGNAL(pressed()), this, SLOT(useTrayButtonPressed()));
 	connect(ui->pushButton2, SIGNAL(pressed()), this, SLOT(pauseButtonPressed()));
 	connect(ui->comboBoxPriority, SIGNAL(currentIndexChanged(int)), this, SLOT(priorityChanged(int)));
@@ -227,8 +234,13 @@ void DIA_encodingQt4::setPhasis(const char *n)
 */
 void DIA_encodingQt4::setFileName(const char *n)
 {
-    outputFileName = n;    // dont copy string, just the pointer.
-    ui->labelFN->setText(QString::fromUtf8(outputFileName));
+    outputFileName = n;    // dont copy string, the pointer is fine.
+    ui->lineEditFN->clear();
+    if (outputFileName)
+    {
+        ui->lineEditFN->insert(QString::fromUtf8(outputFileName));
+        ui->lineEditFN->setCursorPosition(0);
+    }
 }
 
 /**
@@ -450,6 +462,22 @@ void DIA_encodingQt4::keepOpen(void)
             ADM_usleep(100*1000);
             QCoreApplication::processEvents();
         }
+    }
+
+    if (deleteStats && outputFileName)
+    {
+        // try to delete stats files (they may not exists):
+        // filename_with_extension.stats
+        // filename_with_extension.stats.mbtree
+        // filename_with_extension.stats.cutree
+        char * tmpfn = (char*)ADM_alloc(strlen(outputFileName)+32);
+        #define DELETE_MACRO(x)	strcpy(tmpfn, outputFileName); strcat(tmpfn, x); \
+                ADM_info("Delete %s: %s\n",tmpfn,(remove(tmpfn)? "failed":"succeeded"));
+        DELETE_MACRO(".stats");
+        DELETE_MACRO(".stats.mbtree");
+        DELETE_MACRO(".stats.cutree");
+        #undef DELETE_MACRO
+        ADM_dezalloc(tmpfn);
     }
 }
 

--- a/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_encoding.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_encoding.cpp
@@ -234,7 +234,13 @@ void DIA_encodingQt4::setPhasis(const char *n)
 */
 void DIA_encodingQt4::setFileName(const char *n)
 {
-    outputFileName = n;    // dont copy string, the pointer is fine.
+    if (outputFileName)
+        ADM_dezalloc(outputFileName);
+    if (n)
+    {
+        outputFileName = (char*)ADM_alloc(strlen(n)+1);
+        strcpy(outputFileName,n);
+    }
     ui->lineEditFN->clear();
     if (outputFileName)
     {

--- a/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_encoding.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_encoding.cpp
@@ -158,6 +158,7 @@ DIA_encodingQt4::DIA_encodingQt4(uint64_t duration) : DIA_encodingBase(duration)
         qtRegisterDialog(this);
         show();
         tray=NULL;
+        outputFileName=NULL;
 }
 /**
     \fn setFps(uint32_t fps)
@@ -220,6 +221,16 @@ void DIA_encodingQt4::setPhasis(const char *n)
         WRITEM(labelPhasis,n);
     }
 }
+
+/**
+    \fn setFileName(const char *n)
+*/
+void DIA_encodingQt4::setFileName(const char *n)
+{
+    outputFileName = n;    // dont copy string, just the pointer.
+    ui->labelFN->setText(QString::fromUtf8(outputFileName));
+}
+
 /**
     \fn    setFrameCount
     \brief display the # of processed frames

--- a/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_encoding.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_encoding.cpp
@@ -27,7 +27,6 @@
 #include "GUI_ui.h"
 #include "ADM_coreUtils.h"
 #include "ADM_prettyPrint.h"
-#include "ADM_encoderConf.h"
 #include "../ADM_gui/ADM_systemTrayProgress.h" // this is Qt only
 
 //*******************************************
@@ -167,6 +166,7 @@ DIA_encodingQt4::DIA_encodingQt4(uint64_t duration) : DIA_encodingBase(duration)
         show();
         tray=NULL;
         outputFileName=NULL;
+        logFileName=NULL;
 }
 /**
     \fn setFps(uint32_t fps)
@@ -209,6 +209,9 @@ DIA_encodingQt4::~DIA_encodingQt4( )
     if (outputFileName)
         ADM_dezalloc(outputFileName);
     outputFileName=NULL;
+    if (logFileName)
+        ADM_dezalloc(logFileName);
+    logFileName=NULL;
 }
 /**
     \fn setPhasis(const char *n)
@@ -234,22 +237,32 @@ void DIA_encodingQt4::setPhasis(const char *n)
 }
 
 /**
-    \fn setFileName(const char *n)
+    \fn setFileName(const char *n, const char *l)
 */
-void DIA_encodingQt4::setFileName(const char *n)
+void DIA_encodingQt4::setFileName(const char *n, const char *l)
 {
-    if (outputFileName)
-        ADM_dezalloc(outputFileName);
-    if (n)
+    if (!outputFileName)
     {
-        outputFileName = (char*)ADM_alloc(strlen(n)+1);
-        strcpy(outputFileName,n);
+        if (n)
+        {
+            outputFileName = (char*)ADM_alloc(strlen(n)+1);
+            strcpy(outputFileName,n);
+        }
+        ui->lineEditFN->clear();
+        if (outputFileName)
+        {
+            ui->lineEditFN->insert(QString::fromUtf8(outputFileName));
+            ui->lineEditFN->setCursorPosition(0);
+        }
     }
-    ui->lineEditFN->clear();
-    if (outputFileName)
+    
+    if (!logFileName)
     {
-        ui->lineEditFN->insert(QString::fromUtf8(outputFileName));
-        ui->lineEditFN->setCursorPosition(0);
+        if (l)
+        {
+            logFileName = (char*)ADM_alloc(strlen(l)+1);
+            strcpy(logFileName,l);
+        }
     }
 }
 
@@ -474,18 +487,18 @@ void DIA_encodingQt4::keepOpen(void)
         }
     }
 
-    if (deleteStats && outputFileName)
+    if (deleteStats && logFileName)
     {
         // try to delete stats files (they may not exists):
         // filename_with_extension.stats
         // filename_with_extension.stats.mbtree
         // filename_with_extension.stats.cutree
-        char * tmpfn = (char*)ADM_alloc(strlen(outputFileName)+strlen(ADM_2PASS_STATS_FILE_EXTENSION)+16);
-        #define DELETE_MACRO(x)	strcpy(tmpfn, outputFileName); strcat(tmpfn, x); \
+        char * tmpfn = (char*)ADM_alloc(strlen(logFileName)+16);
+        #define DELETE_MACRO(x)	strcpy(tmpfn, logFileName); strcat(tmpfn, x); \
                 ADM_info("Delete %s: %s\n",tmpfn,(remove(tmpfn)? "failed":"succeeded"));
-        DELETE_MACRO(ADM_2PASS_STATS_FILE_EXTENSION);
-        DELETE_MACRO(ADM_2PASS_STATS_FILE_EXTENSION".mbtree");
-        DELETE_MACRO(ADM_2PASS_STATS_FILE_EXTENSION".cutree");
+        DELETE_MACRO("");
+        DELETE_MACRO(".mbtree");
+        DELETE_MACRO(".cutree");
         #undef DELETE_MACRO
         ADM_dezalloc(tmpfn);
     }

--- a/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_encoding.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_encoding.cpp
@@ -27,6 +27,7 @@
 #include "GUI_ui.h"
 #include "ADM_coreUtils.h"
 #include "ADM_prettyPrint.h"
+#include "ADM_encoderConf.h"
 #include "../ADM_gui/ADM_systemTrayProgress.h" // this is Qt only
 
 //*******************************************
@@ -479,12 +480,12 @@ void DIA_encodingQt4::keepOpen(void)
         // filename_with_extension.stats
         // filename_with_extension.stats.mbtree
         // filename_with_extension.stats.cutree
-        char * tmpfn = (char*)ADM_alloc(strlen(outputFileName)+32);
+        char * tmpfn = (char*)ADM_alloc(strlen(outputFileName)+strlen(ADM_2PASS_STATS_FILE_EXTENSION)+16);
         #define DELETE_MACRO(x)	strcpy(tmpfn, outputFileName); strcat(tmpfn, x); \
                 ADM_info("Delete %s: %s\n",tmpfn,(remove(tmpfn)? "failed":"succeeded"));
-        DELETE_MACRO(".stats");
-        DELETE_MACRO(".stats.mbtree");
-        DELETE_MACRO(".stats.cutree");
+        DELETE_MACRO(ADM_2PASS_STATS_FILE_EXTENSION);
+        DELETE_MACRO(ADM_2PASS_STATS_FILE_EXTENSION".mbtree");
+        DELETE_MACRO(ADM_2PASS_STATS_FILE_EXTENSION".cutree");
         #undef DELETE_MACRO
         ADM_dezalloc(tmpfn);
     }

--- a/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_encoding.h
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_encoding.h
@@ -53,11 +53,13 @@ protected:
     Ui_encodingDialog   *ui;    
     ADM_tray            *tray;
     char *              outputFileName;
+    char *              logFileName;
 public:    
     void *WINDOW;
     
     void setPhasis(const char *n);
-    void setFileName(const char *n);
+    void setFileName(const char *n) {setFileName(n, NULL);};
+    void setFileName(const char *n, const char *l);
     void setAudioCodec(const char *n);
     void setVideoCodec(const char *n);
     void setBitrate(uint32_t br,uint32_t globalbr);

--- a/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_encoding.h
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_encoding.h
@@ -51,10 +51,12 @@ protected:
     bool                firstPass;
     Ui_encodingDialog   *ui;    
     ADM_tray            *tray;
+    const char *        outputFileName;
 public:    
     void *WINDOW;
     
     void setPhasis(const char *n);
+    void setFileName(const char *n);
     void setAudioCodec(const char *n);
     void setVideoCodec(const char *n);
     void setBitrate(uint32_t br,uint32_t globalbr);

--- a/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_encoding.h
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_encoding.h
@@ -52,7 +52,7 @@ protected:
     bool                firstPass;
     Ui_encodingDialog   *ui;    
     ADM_tray            *tray;
-    const char *        outputFileName;
+    char *              outputFileName;
 public:    
     void *WINDOW;
     

--- a/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_encoding.h
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_encoding.h
@@ -48,6 +48,7 @@ protected:
 
     bool                stopRequest;
     bool                stayOpen;
+    bool                deleteStats;
     bool                firstPass;
     Ui_encodingDialog   *ui;    
     ADM_tray            *tray;
@@ -70,6 +71,7 @@ public:
     void priorityChanged(int priorityLevel);
     void shutdownChanged(int state);
     void keepOpenChanged(int state);
+    void deleteStatsChanged(int state);
     void closeEvent(QCloseEvent *event);
     void reject(void);
 

--- a/avidemux/qt4/ADM_userInterfaces/ADM_dialog/encoding.ui
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_dialog/encoding.ui
@@ -43,11 +43,48 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout">
        <item>
-        <layout class="QGridLayout" name="gridLayout">
-         <item row="1" column="0">
-          <widget class="QLabel" name="label_26">
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <widget class="QLabel" name="labelFileName">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="text">
-            <string>Time Remaining:</string>
+            <string>File:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="labelFN">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string notr="true">TextLabel</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="1">
+          <widget class="QLabel" name="labelPhasis">
+           <property name="text">
+            <string>None</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_2">
+           <property name="text">
+            <string>Phase:</string>
            </property>
           </widget>
          </item>
@@ -61,13 +98,6 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="1">
-          <widget class="QLabel" name="labelPhasis">
-           <property name="text">
-            <string>None</string>
-           </property>
-          </widget>
-         </item>
          <item row="1" column="1">
           <widget class="QLabel" name="labelETA">
            <property name="text">
@@ -75,10 +105,10 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="label_2">
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_26">
            <property name="text">
-            <string>Phase:</string>
+            <string>Time Remaining:</string>
            </property>
           </widget>
          </item>

--- a/avidemux/qt4/ADM_userInterfaces/ADM_dialog/encoding.ui
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_dialog/encoding.ui
@@ -58,17 +58,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QLabel" name="labelFN">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string notr="true">TextLabel</string>
-           </property>
-          </widget>
+          <widget class="QLineEdit" name="lineEditFN"/>
          </item>
         </layout>
        </item>
@@ -211,6 +201,30 @@
             <size>
              <width>48</width>
              <height>17</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QCheckBox" name="checkBoxDeleteStats">
+           <property name="text">
+            <string>Delete temporary stats files of the first pass</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
             </size>
            </property>
           </spacer>

--- a/avidemux/qt4/ADM_userInterfaces/ADM_dialog/encoding.ui
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_dialog/encoding.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>520</width>
-    <height>317</height>
+    <width>494</width>
+    <height>352</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -42,26 +42,6 @@
        <string>Main</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout">
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_2">
-         <item>
-          <widget class="QLabel" name="labelFileName">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>File:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLineEdit" name="lineEditFN"/>
-         </item>
-        </layout>
-       </item>
        <item>
         <layout class="QGridLayout" name="gridLayout">
          <item row="0" column="1">
@@ -105,6 +85,46 @@
         </layout>
        </item>
        <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>5</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <widget class="QLabel" name="labelFileName">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>File:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="lineEditFN">
+           <property name="readOnly">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
         <spacer name="verticalSpacer1">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -115,7 +135,7 @@
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>8</height>
+           <height>16</height>
           </size>
          </property>
         </spacer>

--- a/avidemux_core/ADM_coreMuxer/include/ADM_muxer.h
+++ b/avidemux_core/ADM_coreMuxer/include/ADM_muxer.h
@@ -84,7 +84,7 @@ protected:
 
 public:
                           ADM_muxer() {vStream=NULL;aStreams=NULL;nbAStreams=0;encoding=NULL;outputFileName=NULL;};
-        virtual           ~ADM_muxer() {closeUI();};
+        virtual           ~ADM_muxer() {closeUI();  if (outputFileName) ADM_dezalloc(outputFileName); outputFileName=NULL;};
         virtual bool      open(const char *filename,   ADM_videoStream *videoStream,
                                 uint32_t nbAudioTrack, ADM_audioStream **audioStreams)=0;
 

--- a/avidemux_core/ADM_coreMuxer/include/ADM_muxer.h
+++ b/avidemux_core/ADM_coreMuxer/include/ADM_muxer.h
@@ -79,9 +79,11 @@ protected:
                 uint64_t videoIncrement; // Used/set by initUI
                 uint64_t videoDuration;
                 DIA_encodingBase *encoding;
+                
+                char *           outputFileName;
 
 public:
-                          ADM_muxer() {vStream=NULL;aStreams=NULL;nbAStreams=0;encoding=NULL;};
+                          ADM_muxer() {vStream=NULL;aStreams=NULL;nbAStreams=0;encoding=NULL;outputFileName=NULL;};
         virtual           ~ADM_muxer() {closeUI();};
         virtual bool      open(const char *filename,   ADM_videoStream *videoStream,
                                 uint32_t nbAudioTrack, ADM_audioStream **audioStreams)=0;
@@ -89,6 +91,7 @@ public:
         virtual  bool     save(void)=0;
         virtual  bool     close(void)=0; 
         virtual  DIA_encodingBase *getEncoding(void) { return encoding; };
+        virtual  void     setOutputFileName(const char * fn);
         virtual  bool     initUI(const char *title);
         virtual  bool     createUI(uint64_t duration);
         virtual  bool     updateUI(void);

--- a/avidemux_core/ADM_coreMuxer/src/ADM_muxerUtils.cpp
+++ b/avidemux_core/ADM_coreMuxer/src/ADM_muxerUtils.cpp
@@ -151,8 +151,6 @@ bool     ADM_muxer::closeUI(void)
         delete encoding;
     }
     encoding=NULL;
-    if (outputFileName)
-        ADM_dezalloc(outputFileName);
     return true;
 }
 // EOF

--- a/avidemux_core/ADM_coreMuxer/src/ADM_muxerUtils.cpp
+++ b/avidemux_core/ADM_coreMuxer/src/ADM_muxerUtils.cpp
@@ -73,6 +73,21 @@ uint64_t rescaleLavPts(uint64_t us, AVRational *scale)
     i*=scale->num;
     return i;
 }
+
+/**
+    \fn     setOutputFileName
+*/
+void ADM_muxer::setOutputFileName(const char * fn)
+{
+    if (outputFileName)
+        ADM_dezalloc(outputFileName);
+    int fnlen = 0;
+    if (fn)
+        fnlen = strlen(fn)+1;
+    outputFileName = (char*)ADM_alloc(fnlen);
+    memcpy(outputFileName, fn, fnlen);
+}
+
 /**
     \fn     initUI
     \brief  initialize the progress bar
@@ -102,6 +117,7 @@ bool     ADM_muxer::initUI(const char *title)
 bool ADM_muxer::createUI(uint64_t duration)
 {
     encoding=createEncoding(duration);
+    encoding->setFileName(outputFileName);
     return true;
 }
 
@@ -135,6 +151,8 @@ bool     ADM_muxer::closeUI(void)
         delete encoding;
     }
     encoding=NULL;
+    if (outputFileName)
+        ADM_dezalloc(outputFileName);
     return true;
 }
 // EOF

--- a/avidemux_core/ADM_coreUI/include/DIA_encoding.h
+++ b/avidemux_core/ADM_coreUI/include/DIA_encoding.h
@@ -74,6 +74,7 @@ public:
                 virtual void setPercent(uint32_t percent)=0;
                 virtual void setRemainingTimeMS(uint32_t nb)=0;
                 virtual void setPhasis(const char *n)=0;
+                virtual void setFileName(const char *n)=0;
                 virtual void setVideoCodec(const char *n)=0;
                 virtual void setAudioCodec(const char *n)=0;
                 virtual void setContainer(const char *container)=0;

--- a/avidemux_core/ADM_coreUI/include/DIA_encoding.h
+++ b/avidemux_core/ADM_coreUI/include/DIA_encoding.h
@@ -75,6 +75,7 @@ public:
                 virtual void setRemainingTimeMS(uint32_t nb)=0;
                 virtual void setPhasis(const char *n)=0;
                 virtual void setFileName(const char *n)=0;
+                virtual void setFileName(const char *n, const char *l)=0;
                 virtual void setVideoCodec(const char *n)=0;
                 virtual void setAudioCodec(const char *n)=0;
                 virtual void setContainer(const char *container)=0;

--- a/avidemux_core/ADM_coreVideoEncoder/include/ADM_encoderConf.h
+++ b/avidemux_core/ADM_coreVideoEncoder/include/ADM_encoderConf.h
@@ -38,6 +38,8 @@ typedef enum
 
 #define ADM_EXTRA_PARAM_JS 0x100
 #define ADM_EXTRA_PARAM    0x200
+
+#define ADM_2PASS_STATS_FILE_EXTENSION	".stats"
 /**
     \struct COMPRES_PARAMS
     \brief Simple declaration of an encoder setting

--- a/avidemux_plugins/ADM_muxers/muxerAvi/muxerAvi.cpp
+++ b/avidemux_plugins/ADM_muxers/muxerAvi/muxerAvi.cpp
@@ -89,6 +89,7 @@ bool muxerAvi::open(const char *file, ADM_videoStream *s,uint32_t nbAudioTrack,A
         vStream=s;
         nbAStreams=nbAudioTrack;
         aStreams=a;
+        setOutputFileName(file);
         clocks=new audioClock*[nbAStreams];
         for(int i=0;i<nbAStreams;i++)
             clocks[i]=new audioClock(a[i]->getInfo()->frequency);

--- a/avidemux_plugins/ADM_muxers/muxerDummy/ADM_dummy.cpp
+++ b/avidemux_plugins/ADM_muxers/muxerDummy/ADM_dummy.cpp
@@ -7,6 +7,7 @@ bool muxerDummy::open(const char *file, ADM_videoStream *s,uint32_t nbAudioTrack
 {
                 printf("[DummyMuxer] Opening %s\n",file);
                 vStream=s;
+                setOutputFileName(file);
                 return true;
 }
 

--- a/avidemux_plugins/ADM_muxers/muxerFlv/muxerFlv.cpp
+++ b/avidemux_plugins/ADM_muxers/muxerFlv/muxerFlv.cpp
@@ -142,6 +142,7 @@ finish:
         vStream=s;
         aStreams=a;
         nbAStreams=nbAudioTrack;
+        setOutputFileName(file);
         return r;
 }
 

--- a/avidemux_plugins/ADM_muxers/muxerMkv/muxerMkv.cpp
+++ b/avidemux_plugins/ADM_muxers/muxerMkv/muxerMkv.cpp
@@ -208,6 +208,7 @@ bool MKVCLASS::open(const char *file, ADM_videoStream *s, uint32_t nbAudioTrack,
     vStream=s;
     aStreams=a;
     nbAStreams=nbAudioTrack;
+    setOutputFileName(file);
     initialized=true;
     return true;
 }

--- a/avidemux_plugins/ADM_muxers/muxerMp4/muxerMP4.cpp
+++ b/avidemux_plugins/ADM_muxers/muxerMp4/muxerMP4.cpp
@@ -340,6 +340,7 @@ bool MOVCLASS::open(const char *file, ADM_videoStream *s, uint32_t nbAudioTrack,
         vStream=s;
         aStreams=a;
         nbAStreams=nbAudioTrack;
+        setOutputFileName(file);
         initialized=true;
         return true;
 }

--- a/avidemux_plugins/ADM_muxers/muxerMp4v2/muxerMp4v2.cpp
+++ b/avidemux_plugins/ADM_muxers/muxerMp4v2/muxerMp4v2.cpp
@@ -152,6 +152,7 @@ bool muxerMp4v2::open(const char *file, ADM_videoStream *s,uint32_t nbAudioTrack
         audioDelay=s->getVideoDelay();
         vStream=s;
         nbAStreams=nbAudioTrack;
+        setOutputFileName(file);
         aStreams=a;
         videoBufferSize=vStream->getWidth()*vStream->getHeight()*3;
         videoBuffer[0]=new uint8_t[videoBufferSize];

--- a/avidemux_plugins/ADM_muxers/muxerRaw/muxerRaw.cpp
+++ b/avidemux_plugins/ADM_muxers/muxerRaw/muxerRaw.cpp
@@ -62,6 +62,7 @@ bool muxerRaw::open(const char *fil, ADM_videoStream *s,uint32_t nbAudioTrack,AD
         printf("[RawMuxer] Cannot open %s\n",fil);
         return false;
     }
+    setOutputFileName(fil);
     return true;
 }
 

--- a/avidemux_plugins/ADM_muxers/muxerffPS/muxerffPS.cpp
+++ b/avidemux_plugins/ADM_muxers/muxerffPS/muxerffPS.cpp
@@ -151,6 +151,7 @@ bool muxerffPS::open(const char *file, ADM_videoStream *s,uint32_t nbAudioTrack,
         vStream=s;
         aStreams=a;
         nbAStreams=nbAudioTrack;
+        setOutputFileName(file);
         initialized=true;
         return true;
 }

--- a/avidemux_plugins/ADM_muxers/muxerffTS/muxerffTS.cpp
+++ b/avidemux_plugins/ADM_muxers/muxerffTS/muxerffTS.cpp
@@ -149,6 +149,7 @@ bool muxerffTS::open(const char *file, ADM_videoStream *s,uint32_t nbAudioTrack,
         vStream=s;
         aStreams=a;
         nbAStreams=nbAudioTrack;
+        setOutputFileName(file);
         initialized=true;
         return true;
 }


### PR DESCRIPTION
In the Encoding dialog the output filename with full path is shown.
There is a checkboxed option to delete temporary stats files after encoding is done.
If enabled, it will try to delete:

- filename_with_extension.stats
- filename_with_extension.stats.mbtree
- filename_with_extension.stats.cutree

