### PR TITLE
Add SSE4 .. AVX2 + bugfix

### DIFF
--- a/avidemux/common/ADM_commonUI/DIA_prefs.cpp
+++ b/avidemux/common/ADM_commonUI/DIA_prefs.cpp
@@ -87,7 +87,7 @@ bool     blibva=false;
 bool     bvideotoolbox=false;
 #endif
 bool     hzd,vzd,dring;
-bool     capsMMX,capsMMXEXT,caps3DNOW,caps3DNOWEXT,capsSSE,capsSSE2,capsSSE3,capsSSSE3,capsAll;
+bool     capsMMX,capsMMXEXT,caps3DNOW,caps3DNOWEXT,capsSSE,capsSSE2,capsSSE3,capsSSSE3,capsSSE4,capsSSE42,capsAVX,capsAVX2,capsAll;
 bool     hasOpenGl=false;
 
 bool     refreshCapEnabled=false;
@@ -132,6 +132,10 @@ std::string currentSdlDriver=getSdlDriverName();
     	CPU_CAPS(SSE2);
     	CPU_CAPS(SSE3);
     	CPU_CAPS(SSSE3);
+    	CPU_CAPS(SSE4);
+    	CPU_CAPS(SSE42);
+    	CPU_CAPS(AVX);
+    	CPU_CAPS(AVX2);
 
     	//Avisynth
     	if(!prefs->get(AVISYNTH_AVISYNTH_ALWAYS_ASK, &askPortAvisynth))
@@ -271,6 +275,10 @@ std::string currentSdlDriver=getSdlDriverName();
         diaElemToggle capsToggleSSE2(&capsSSE2, QT_TRANSLATE_NOOP("adm","Enable SSE2"));
         diaElemToggle capsToggleSSE3(&capsSSE3, QT_TRANSLATE_NOOP("adm","Enable SSE3"));
         diaElemToggle capsToggleSSSE3(&capsSSSE3, QT_TRANSLATE_NOOP("adm","Enable SSSE3"));
+        diaElemToggle capsToggleSSE4(&capsSSE4, QT_TRANSLATE_NOOP("adm","Enable SSE4"));
+        diaElemToggle capsToggleSSE42(&capsSSE42, QT_TRANSLATE_NOOP("adm","Enable SSE4.2"));
+        diaElemToggle capsToggleAVX(&capsAVX, QT_TRANSLATE_NOOP("adm","Enable AVX"));
+        diaElemToggle capsToggleAVX2(&capsAVX2, QT_TRANSLATE_NOOP("adm","Enable AVX2"));
 
         capsToggleAll.link(0, &capsToggleMMX);
         capsToggleAll.link(0, &capsToggleMMXEXT);
@@ -280,6 +288,10 @@ std::string currentSdlDriver=getSdlDriverName();
         capsToggleAll.link(0, &capsToggleSSE2);
         capsToggleAll.link(0, &capsToggleSSE3);
         capsToggleAll.link(0, &capsToggleSSSE3);
+        capsToggleAll.link(0, &capsToggleSSE4);
+        capsToggleAll.link(0, &capsToggleSSE42);
+        capsToggleAll.link(0, &capsToggleAVX);
+        capsToggleAll.link(0, &capsToggleAVX2);
 
         frameSimd.swallow(&capsToggleAll);
         frameSimd.swallow(&capsToggleMMX);
@@ -290,6 +302,10 @@ std::string currentSdlDriver=getSdlDriverName();
         frameSimd.swallow(&capsToggleSSE2);
         frameSimd.swallow(&capsToggleSSE3);
         frameSimd.swallow(&capsToggleSSSE3);
+        frameSimd.swallow(&capsToggleSSE4);
+        frameSimd.swallow(&capsToggleSSE42);
+        frameSimd.swallow(&capsToggleAVX);
+        frameSimd.swallow(&capsToggleAVX2);
 
         diaElemThreadCount lavcThreadCount(&lavcThreads, QT_TRANSLATE_NOOP("adm","_lavc threads:"));
 
@@ -589,6 +605,10 @@ std::string currentSdlDriver=getSdlDriverName();
                     CPU_CAPS(SSE2);
                     CPU_CAPS(SSE3);
                     CPU_CAPS(SSSE3);
+                    CPU_CAPS(SSE4);
+                    CPU_CAPS(SSE42);
+                    CPU_CAPS(AVX);
+                    CPU_CAPS(AVX2);
             }
             prefs->set(FEATURES_CPU_CAPS,cpuMaskOut);
             CpuCaps::setMask(cpuMaskOut);

--- a/avidemux/common/ADM_commonUI/DIA_prefs.cpp
+++ b/avidemux/common/ADM_commonUI/DIA_prefs.cpp
@@ -495,7 +495,7 @@ std::string currentSdlDriver=getSdlDriverName();
 
         /* Output */
         diaElem *diaOutput[]={&allowAnyMpeg, &useLastReadAsTarget, &firstPassLogFilesAutoDelete, &frameMultiLoad, &frameCache};
-        diaElemTabs tabOutput(QT_TRANSLATE_NOOP("adm","Output"),4,(diaElem **)diaOutput);
+        diaElemTabs tabOutput(QT_TRANSLATE_NOOP("adm","Output"),5,(diaElem **)diaOutput);
 
         /* Audio */
 

--- a/avidemux_core/ADM_core/include/ADM_cpuCap.h
+++ b/avidemux_core/ADM_core/include/ADM_cpuCap.h
@@ -39,6 +39,10 @@ typedef enum
         ADM_CPUCAP_SSE3   =1<<7,
         ADM_CPUCAP_SSSE3  =1<<8,
         ADM_CPUCAP_ALTIVEC=1<<9,
+        ADM_CPUCAP_SSE4   =1<<10,
+        ADM_CPUCAP_SSE42  =1<<11,
+        ADM_CPUCAP_AVX    =1<<12,
+        ADM_CPUCAP_AVX2    =1<<13,
         
         ADM_CPUCAP_ALL=0x0fffffff
 } ADM_CPUCAP;
@@ -63,6 +67,10 @@ public:
 	static uint8_t 	hasSSE3 (void){CHECK_Z(SSE3)};
 	static uint8_t 	hasSSSE3 (void){CHECK_Z(SSSE3)};
 	static uint8_t 	has3DNOWEXT(void){CHECK_Z(3DNOWEXT)};
+	static uint8_t 	hasSSE4 (void){CHECK_Z(SSE4)};
+	static uint8_t 	hasSSE42 (void){CHECK_Z(SSE42)};
+	static uint8_t 	hasAVX (void){CHECK_Z(AVX)};
+	static uint8_t 	hasAVX2 (void){CHECK_Z(AVX2)};
 
 
 };

--- a/avidemux_core/ADM_core/src/ADM_cpuCap.cpp
+++ b/avidemux_core/ADM_core/src/ADM_cpuCap.cpp
@@ -83,6 +83,19 @@ extern "C"
       	 myCpuCaps |= ADM_CPUCAP_SSE3;
        if (ecx & 0x00000200 )
       	 myCpuCaps |= ADM_CPUCAP_SSSE3;
+       if (ecx & (1<<19) )
+      	 myCpuCaps |= ADM_CPUCAP_SSE4;
+       if (ecx & (1<<20) )
+      	 myCpuCaps |= ADM_CPUCAP_SSE42;
+       if (ecx & (1<<28) )
+      	 myCpuCaps |= ADM_CPUCAP_AVX;
+   }
+   if(max_std_level >= 7)
+   {
+       ecx=0;
+       adm_cpu_cpuid(7, &eax, &ebx, &ecx, &edx);
+       if (ebx & (1<<5) )
+      	 myCpuCaps |= ADM_CPUCAP_AVX2;
    }
 
    adm_cpu_cpuid(0x80000000,& max_ext_level,& ebx, &ecx,& edx);
@@ -173,6 +186,10 @@ static int Cpu2Lav(uint32_t admMask)
     	LAV_CPU_CAPS(SSE2);
     	LAV_CPU_CAPS(SSE3);
     	LAV_CPU_CAPS(SSSE3);
+    	LAV_CPU_CAPS(SSE4);
+    	LAV_CPU_CAPS(SSE42);
+    	LAV_CPU_CAPS(AVX);
+    	LAV_CPU_CAPS(AVX2);
         return out;
 }
 
@@ -187,7 +204,8 @@ bool     CpuCaps::setMask(uint32_t mask)
     myCpuMask=mask;
 
     int lavCpuMask=Cpu2Lav(myCpuMask);
-    av_set_cpu_flags_mask(lavCpuMask);
+    //av_set_cpu_flags_mask(lavCpuMask); deprecated!
+    av_force_cpu_flags(lavCpuMask);
 
     return true;
 }

--- a/avidemux_core/ADM_coreUI/include/DIA_factory.h
+++ b/avidemux_core/ADM_coreUI/include/DIA_factory.h
@@ -84,7 +84,7 @@ public:
   virtual int getRequiredLayout(void)=0;
 };
 /*********************************************/
-#define MENU_MAX_lINK 10
+#define MENU_MAX_lINK 16
 typedef struct dialElemLink
 {
   uint32_t  value;


### PR DESCRIPTION
Add SSE4,SSE4.2,AVX,AVX2 CPU capabilities.
Fix missing cache options.

PS: Does encoders ignores the CPU capabilities settings? Did not saw performance difference in x265, where in theory AVX should matter.