### PR TITLE
[hdr] show changes

### DIFF
--- a/avidemux/common/ADM_commonUI/DIA_HDRConfig.cpp
+++ b/avidemux/common/ADM_commonUI/DIA_HDRConfig.cpp
@@ -13,7 +13,7 @@
 
 int DIA_getHDRParams( uint32_t * toneMappingMethod, float * saturationAdjust, float * boostAdjust)
 {
-    diaElemReadOnlyText applicability(NULL,QT_TRANSLATE_NOOP("adm","The options above are not immediately effective on cached and displayed frames"),NULL);
+    //diaElemReadOnlyText applicability(NULL,QT_TRANSLATE_NOOP("adm","The options above are not immediately effective on cached and displayed frames"),NULL);
     
     diaMenuEntry toneMapEntries[]={
                           {0,       QT_TRANSLATE_NOOP("adm","disabled"),NULL}
@@ -28,9 +28,9 @@ int DIA_getHDRParams( uint32_t * toneMappingMethod, float * saturationAdjust, fl
     diaElemFloat floatSaturationHDR(saturationAdjust,QT_TRANSLATE_NOOP("adm","_Saturation:"),0.,10.);
     diaElemFloat floatBoostHDR(boostAdjust,QT_TRANSLATE_NOOP("adm","_Boost (level multiplier):"),0.,10.);
 
-    diaElem *elems[6]={ &menuToneMapHDR, &floatSaturationHDR, &floatBoostHDR, &applicability };
+    diaElem *elems[6]={ &menuToneMapHDR, &floatSaturationHDR, &floatBoostHDR, /*&applicability*/ };
 
-    if(diaFactoryRun("HDR tone mapping",4,elems))
+    if(diaFactoryRun("HDR tone mapping",3,elems))
     {
         return 1;
     }

--- a/avidemux/common/ADM_commonUI/DIA_HDRConfig.cpp
+++ b/avidemux/common/ADM_commonUI/DIA_HDRConfig.cpp
@@ -13,7 +13,7 @@
 
 int DIA_getHDRParams( uint32_t * toneMappingMethod, float * saturationAdjust, float * boostAdjust)
 {
-    //diaElemReadOnlyText applicability(NULL,QT_TRANSLATE_NOOP("adm","The options above are not immediately effective on cached and displayed frames"),NULL);
+    diaElemReadOnlyText applicability(NULL,QT_TRANSLATE_NOOP("adm","Changing the options above will results the editor jumping to the nearest prior key frame."),NULL);
     
     diaMenuEntry toneMapEntries[]={
                           {0,       QT_TRANSLATE_NOOP("adm","disabled"),NULL}
@@ -28,9 +28,9 @@ int DIA_getHDRParams( uint32_t * toneMappingMethod, float * saturationAdjust, fl
     diaElemFloat floatSaturationHDR(saturationAdjust,QT_TRANSLATE_NOOP("adm","_Saturation:"),0.,10.);
     diaElemFloat floatBoostHDR(boostAdjust,QT_TRANSLATE_NOOP("adm","_Boost (level multiplier):"),0.,10.);
 
-    diaElem *elems[6]={ &menuToneMapHDR, &floatSaturationHDR, &floatBoostHDR, /*&applicability*/ };
+    diaElem *elems[6]={ &menuToneMapHDR, &floatSaturationHDR, &floatBoostHDR, &applicability };
 
-    if(diaFactoryRun("HDR tone mapping",3,elems))
+    if(diaFactoryRun("HDR tone mapping",4,elems))
     {
         return 1;
     }

--- a/avidemux/common/gui_main.cpp
+++ b/avidemux/common/gui_main.cpp
@@ -1504,6 +1504,11 @@ void    A_setHDRConfig( void )
      if(DIA_getHDRParams( &method, &saturation,&boost))
      {
         video_body->setHDRConfig(method,saturation,boost);
+        admPreview::deferDisplay(true);
+        admPreview::nextPicture();
+        admPreview::previousKeyFrame();
+        admPreview::deferDisplay(false);
+        admPreview::samePicture();
      }
 
 }

--- a/avidemux/common/gui_main.cpp
+++ b/avidemux/common/gui_main.cpp
@@ -1509,6 +1509,7 @@ void    A_setHDRConfig( void )
         admPreview::previousKeyFrame();
         admPreview::deferDisplay(false);
         admPreview::samePicture();
+        GUI_setCurrentFrameAndTime();
      }
 
 }


### PR DESCRIPTION
use nextPicture()+previousKeyFrame() to flush cache, and display the effect of the new hdr settings on the closest (prev or same) key frame.