### PR TITLE
[ADM_preview] omit error message if can not go to the next/prev keyframe, but there is none to go to

### DIFF
--- a/avidemux/common/ADM_preview.h
+++ b/avidemux/common/ADM_preview.h
@@ -39,8 +39,8 @@ class admPreview
       static void cleanUp(void);
       static ADMImage *getBuffer(void);
       static uint64_t getCurrentPts(void);
-      static bool nextKeyFrame(void);
-      static bool previousKeyFrame(void);
+      static bool nextKeyFrame(bool * keyframeNotFound = NULL);
+      static bool previousKeyFrame(bool * keyframeNotFound = NULL);
       static bool previousFrame(void);
       static void destroy(void);
       static bool updateImage(void);

--- a/avidemux/common/ADM_previewNavigate.cpp
+++ b/avidemux/common/ADM_previewNavigate.cpp
@@ -130,15 +130,19 @@ uint8_t admPreview::previousPicture(void)
     \fn nextKeyFrame
 
 */
-bool admPreview::nextKeyFrame(void)
+bool admPreview::nextKeyFrame(bool * keyframeNotFound)
 {
     uint64_t pts=getCurrentPts();
     ADM_info("Current PTS :%" PRId64" ms\n",pts/1000LL);
     if(false==video_body->getNKFramePTS(&pts))
     {
         ADM_warning("Cannot find next keyframe\n");
+        if (keyframeNotFound)
+            *keyframeNotFound = true;
         return false;
     }
+    if (keyframeNotFound)
+        *keyframeNotFound = false;
     ADM_info("next kf PTS :%" PRId64" ms\n",pts/1000LL);
     return seekToIntraPts(pts);
 }
@@ -146,15 +150,19 @@ bool admPreview::nextKeyFrame(void)
     \fn previousKeyFrame
 
 */
-bool admPreview::previousKeyFrame(void)
+bool admPreview::previousKeyFrame(bool * keyframeNotFound)
 {
     uint64_t pts=getCurrentPts();
     ADM_info("Current PTS :%" PRId64" ms\n",pts/1000LL);
     if(false==video_body->getPKFramePTS(&pts))
     {
         ADM_warning("Cannot find previous keyframe\n");
+        if (keyframeNotFound)
+            *keyframeNotFound = true;
         return false;
     }
+    if (keyframeNotFound)
+        *keyframeNotFound = false;
     ADM_info("next kf PTS :%" PRId64" ms\n",pts/1000LL);
     return seekToIntraPts(pts);
 }

--- a/avidemux/common/gui_navigate.cpp
+++ b/avidemux/common/gui_navigate.cpp
@@ -322,12 +322,15 @@ bool GUI_NextKeyFrame(void)
         return false;
     if (!avifileinfo)
         return false;
+    
+    bool keyframeNotFound;
 
-    if (!admPreview::nextKeyFrame())
-      {
-        A_timedError(&firstError, QT_TRANSLATE_NOOP("navigate","Cannot go to next keyframe"));
+    if (!admPreview::nextKeyFrame(&keyframeNotFound))
+    {
+        if (!keyframeNotFound)
+            A_timedError(&firstError, QT_TRANSLATE_NOOP("navigate","Cannot go to next keyframe"));
         return false;
-      }
+    }
     GUI_setCurrentFrameAndTime();
     UI_purge();
     return true;
@@ -388,12 +391,15 @@ bool GUI_PreviousKeyFrame(void)
         return false;
     if (!avifileinfo)
         return false;
+    
+    bool keyframeNotFound;
 
-    if (!admPreview::previousKeyFrame())
-      {
-        A_timedError(&firstError, QT_TRANSLATE_NOOP("navigate","Cannot go to previous keyframe"));
+    if (!admPreview::previousKeyFrame(&keyframeNotFound))
+    {
+        if (!keyframeNotFound)
+            A_timedError(&firstError, QT_TRANSLATE_NOOP("navigate","Cannot go to previous keyframe"));
         return false;
-      }
+    }
     GUI_setCurrentFrameAndTime();
     UI_purge();
     return true;


### PR DESCRIPTION
i find annoying, when it pops up error message, while at the beginning or at the end of the video
