### PR TITLE
[ADM_videoFilters] bugfix: recreate filter chain if partial filter reconfigured

### DIFF
--- a/avidemux/common/ADM_videoFilter2/src/ADM_videoFilters.cpp
+++ b/avidemux/common/ADM_videoFilter2/src/ADM_videoFilters.cpp
@@ -74,7 +74,7 @@ bool ADM_vf_configureFilterAtIndex(int index)
     ADM_coreVideoFilter *instance=e->instance;
     ADM_assert(instance);
 
-    if(instance->configure() && ((index < nb-1) || (e->tag == VF_PARTIAL_FILTER))) // not the last one
+    if(instance->configure() && ((index < nb-1) || (e->tag == VF_PARTIAL_FILTER))) // not the last one -OR- partial filter (if only partial timing were changed, the child filter might operate noughty, until next chain rebuild)
     {
         return ADM_vf_recreateChain();
     }

--- a/avidemux/common/ADM_videoFilter2/src/ADM_videoFilters.cpp
+++ b/avidemux/common/ADM_videoFilter2/src/ADM_videoFilters.cpp
@@ -74,7 +74,7 @@ bool ADM_vf_configureFilterAtIndex(int index)
     ADM_coreVideoFilter *instance=e->instance;
     ADM_assert(instance);
 
-    if(instance->configure() && index < nb-1) // not the last one
+    if(instance->configure() && ((index < nb-1) || (e->tag == VF_PARTIAL_FILTER))) // not the last one
     {
         return ADM_vf_recreateChain();
     }


### PR DESCRIPTION
The preview of a last partialized Add logo filter had messed up timing if their parent partial filter range changed.