### PR TITLE
[gui_main] prevent crash when restoring previous session with deleted video

### DIFF
--- a/avidemux/common/gui_main.cpp
+++ b/avidemux/common/gui_main.cpp
@@ -1382,11 +1382,14 @@ bool A_checkSavedSession(bool load)
         {
             ADM_info("Restoring the last editing state from %s\n",where.c_str());
             r=A_parseScript(engine,where.c_str());
-            video_body->rewind();
-            admPreview::samePicture();
-            A_Resync();
-            if(!ADM_eraseFile(where.c_str()))
-                ADM_warning("Could not delete %s\n",where.c_str());
+            if (r)
+            {
+                video_body->rewind();
+                admPreview::samePicture();
+                A_Resync();
+                if(!ADM_eraseFile(where.c_str()))
+                    ADM_warning("Could not delete %s\n",where.c_str());
+            }
         }
     }
     return r;


### PR DESCRIPTION
accidentaly tried to restore a previous session, while the source file was already deleted. this led to a crash