### PR TITLE
[ADM_segment] fix crash when loading keyframeless/bogus video while shared cache enabled

### DIFF
--- a/avidemux/common/ADM_editor/src/ADM_segment.cpp
+++ b/avidemux/common/ADM_editor/src/ADM_segment.cpp
@@ -258,7 +258,7 @@ bool        ADM_EditorSegment::addReferenceVideo(_VIDEOS *ref)
     if(!found)
     {
         ADM_warning("Reached the end of ref video while searching for the first keyframe.\n");
-        if(!videos.size())
+        if(!videos.size() && (ref->_videoCache != _sharedVideoCache))
             delete ref->_videoCache;
         ref->_videoCache = NULL;
         if(ref->decoder) delete ref->decoder;


### PR DESCRIPTION
with enabled shared cache it was crashing when trying to load video in
[https://avidemux.org/smif/index.php?msg=92917](https://avidemux.org/smif/index.php?msg=92917)