### PR TITLE
[Q_gui2] event handler only query preference if relevant

### DIFF
--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
@@ -1756,12 +1756,12 @@ bool MainWindow::eventFilter(QObject* watched, QEvent* event)
 {
     QKeyEvent *keyEvent;
     bool swpud=false;
-    prefs->get(KEYBOARD_SHORTCUTS_SWAP_UP_DOWN_KEYS,&swpud);
+    
     switch (event->type())
     {
         case QEvent::KeyPress:
             keyEvent = (QKeyEvent*)event;
-
+            prefs->get(KEYBOARD_SHORTCUTS_SWAP_UP_DOWN_KEYS,&swpud);
 //            if (watched == slider)
             {
                 switch (keyEvent->key())


### PR DESCRIPTION
for example event handler fires rapidly if mouse cursor moving over the main window