### PR TITLE
[ADM_demuxers/Matroska] reuse indexing dialog

### DIFF
--- a/avidemux/cli/ADM_userInterfaces/ADM_dialog/DIA_working.cpp
+++ b/avidemux/cli/ADM_userInterfaces/ADM_dialog/DIA_working.cpp
@@ -39,6 +39,7 @@ public:
     virtual uint8_t     update(uint32_t percent);
     virtual uint8_t     update(uint32_t current,uint32_t total);
     virtual uint8_t     isAlive (void );
+    virtual void        reuseAs( const char *title=NULL );
 
 };
 //**********************************
@@ -119,6 +120,13 @@ uint8_t DIA_workingNone::update(uint32_t cur, uint32_t total)
 uint8_t DIA_workingNone::isAlive (void )
 {
     return 1;
+}
+
+void DIA_workingNone::reuseAs( const char *title )
+{
+    lastper=0;
+    _nextUpdate=0;
+    _clock.reset();
 }
 
 DIA_workingNone::~DIA_workingNone()

--- a/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_working.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_working.cpp
@@ -63,6 +63,7 @@ public:
         virtual uint8_t      update(uint32_t percent);  // If returns 1 -> Means aborted
         virtual uint8_t      update(uint32_t current,uint32_t total); // If returns 1 -> Means aborted
         virtual uint8_t      isAlive (void );
+        virtual void         reuseAs( const char *title=NULL );
                 void         closeDialog(void);
         
 };
@@ -181,6 +182,19 @@ uint8_t DIA_workingQt4::isAlive (void )
     workWindow *wind=(workWindow *)_priv; 
     ADM_assert(wind);
     return wind->active;
+}
+/**
+ * 
+ */
+void DIA_workingQt4::reuseAs( const char *title )
+{
+    lastper=0;
+    _nextUpdate=0; 
+    _clock.reset();
+    workWindow *wind=(workWindow *)_priv;
+    ADM_assert(wind);
+    ADM_assert(title!=NULL);
+    wind->setWindowTitle(QString::fromUtf8(title));    
 }
 /**
  * 

--- a/avidemux_core/ADM_coreUI/include/DIA_working.h
+++ b/avidemux_core/ADM_coreUI/include/DIA_working.h
@@ -41,6 +41,7 @@ class DIA_workingBase
             virtual uint8_t  	update(uint32_t percent) {ADM_assert(0);return 1;}
             virtual uint8_t 	update(uint32_t current,uint32_t total){ADM_assert(0);return 1;};
             virtual uint8_t  	isAlive (void ){ADM_assert(0);return 1;};
+            virtual void        reuseAs( const char *title=NULL ) {ADM_assert(0);};
             
 };
 /**

--- a/avidemux_plugins/ADM_demuxers/Matroska/ADM_mkv.cpp
+++ b/avidemux_plugins/ADM_demuxers/Matroska/ADM_mkv.cpp
@@ -165,22 +165,26 @@ uint8_t mkvHeader::open(const char *name)
   }
   readCue(&ebml);
   printf("[MKV] Indexing clusters\n");
-  uint8_t result=indexClusters(&ebml);
+  DIA_workingBase *work = createWorking("");
+  uint8_t result=indexClusters(&ebml, work);
   if(result!=1)
   {
     if(!result)
         printf("[MKV] Cluster indexing failed\n");
+    delete work;
     return result;
   }
   printf("[MKV]Found %u clusters\n",_clusters.size());
   printf("[MKV] Indexing video\n");
-    result=videoIndexer(&ebml);
+    result=videoIndexer(&ebml, work);
     if(result!=1)
     {
         if(!result)
             printf("[MKV] Video indexing failed\n");
+        delete work;
         return result;
     }
+    delete work;
   // update some infos
   _videostream.dwLength= _mainaviheader.dwTotalFrames=_tracks[0].index.size();;
     if(! _videostream.dwLength)

--- a/avidemux_plugins/ADM_demuxers/Matroska/ADM_mkv.h
+++ b/avidemux_plugins/ADM_demuxers/Matroska/ADM_mkv.h
@@ -26,6 +26,7 @@
 #include "ADM_audioStream.h"
 #include "ADM_aacLatm.h"
 #include "ADM_ebml.h"
+#include "DIA_working.h"
 #include <BVector.h>
 #define MKV_MAX_REPEAT_HEADER_SIZE 16
 /**
@@ -244,9 +245,9 @@ class mkvHeader         :public vidHeader
 
     uint8_t                 addIndexEntry(uint32_t track,ADM_ebml_file *parser,uint64_t where, uint32_t size,uint32_t flags,
                                             uint32_t timecodeMS);
-    uint8_t                 videoIndexer(ADM_ebml_file *parser);
+    uint8_t                 videoIndexer(ADM_ebml_file *parser, DIA_workingBase *work);
     bool                    readCue(ADM_ebml_file *parser);
-    uint8_t                 indexClusters(ADM_ebml_file *parser);
+    uint8_t                 indexClusters(ADM_ebml_file *parser, DIA_workingBase *work);
     uint8_t                 indexBlock(ADM_ebml_file *parser,uint32_t count,uint32_t timecodeMS);
 
     uint8_t                 rescaleTrack(mkvTrak *track,uint32_t durationMs);

--- a/avidemux_plugins/ADM_demuxers/Matroska/ADM_mkvIndexer.cpp
+++ b/avidemux_plugins/ADM_demuxers/Matroska/ADM_mkvIndexer.cpp
@@ -38,14 +38,18 @@
     \fn videoIndexer
     \brief index the video Track
 */
-uint8_t mkvHeader::videoIndexer(ADM_ebml_file *parser)
+uint8_t mkvHeader::videoIndexer(ADM_ebml_file *parser, DIA_workingBase *work)
 {
     uint64_t len,id;
     ADM_MKV_TYPE type;
     const char *ss;
 
     parser->seek(0);
-    DIA_workingBase *work=createWorking(QT_TRANSLATE_NOOP("matroskademuxer","Matroska Images"));
+    if (work == NULL)
+        return 0;
+    if(!work->isAlive())
+        return 0;
+    work->reuseAs(QT_TRANSLATE_NOOP("matroskademuxer","Matroska Images"));
     uint8_t res=1;
 
     readBufferSize=200*1024;
@@ -123,7 +127,6 @@ uint8_t mkvHeader::videoIndexer(ADM_ebml_file *parser)
    // printf("[MKV] ending cluster at 0x%llx\n",segment.tell());
     }
     printf("Found %" PRIu32" images in this video\n",(uint32_t)VIDEO.index.size());
-    delete work;
     delete [] readBuffer;
     readBuffer=NULL;
     return (res==ADM_IGN)? res : !!VIDEO.index.size();
@@ -602,7 +605,7 @@ bool mkvHeader::readCue(ADM_ebml_file *parser)
         \fn indexClusters
         \brief make a list of all clusters with there position & size
 */
-uint8_t mkvHeader::indexClusters(ADM_ebml_file *parser)
+uint8_t mkvHeader::indexClusters(ADM_ebml_file *parser, DIA_workingBase *work)
 {
     uint64_t fileSize,len;
     uint64_t alen,vlen;
@@ -631,7 +634,11 @@ uint8_t mkvHeader::indexClusters(ADM_ebml_file *parser)
     }
     ADM_ebml_file segment(parser,vlen);
 
-    DIA_workingBase *work=createWorking(QT_TRANSLATE_NOOP("matroskademuxer","Matroska clusters"));
+    if (work == NULL)
+        return 0;
+    if(!work->isAlive())
+        return 0;
+    work->reuseAs(QT_TRANSLATE_NOOP("matroskademuxer","Matroska clusters"));
     while(segment.simplefind(MKV_CLUSTER,&alen,0))
     {
         if(!work->isAlive())
@@ -674,7 +681,6 @@ tryAgain:
         segment.seek( _clusters[seekme].pos+ _clusters[seekme].size);
         //printf("Position :%u %u MB\n", _clusters[seekme].pos+ _clusters[seekme].size,( _clusters[seekme].pos+ _clusters[seekme].size)>>20);
     }
-    delete work;
     ADM_info("[MKV] Found %u clusters\n",(int)_clusters.size());
     return res;
 }


### PR DESCRIPTION
prevent very annoying focus stealing, by reusing the same dialog for cluster and image indexing
(wondering if cluster and image indexing could be united into a single process, as after a cluster found image the images in it. this would be faster in case file located on a HDD)

also prevent memory leak (undeleted work)