### PR TITLE
[GUI/audioTracks] show up to 32 tracks

### DIFF
--- a/avidemux/common/ADM_audioFilter/src/audiofilter_interface.cpp
+++ b/avidemux/common/ADM_audioFilter/src/audiofilter_interface.cpp
@@ -31,6 +31,26 @@ bool ADM_AUDIOFILTER_CONFIG::audioFilterConfigure(void)
 }
 
 /**
+    \fn audioFilterCopyConfig
+    \brief
+*/
+bool ADM_AUDIOFILTER_CONFIG::audioFilterCopyConfig(ADM_AUDIOFILTER_CONFIG * other)
+{
+    startTimeInUs=other->startTimeInUs;
+    shiftInMs=other->shiftInMs;
+    mixerEnabled=other->mixerEnabled;
+    mixerConf=other->mixerConf;
+    resamplerEnabled=other->resamplerEnabled;
+    resamplerFrequency=other->resamplerFrequency;
+    film2pal=other->film2pal;
+    gainParam=other->gainParam;
+    drcEnabled=other->drcEnabled;
+    drcConf=other->drcConf;
+    shiftEnabled=other->shiftEnabled;
+    shiftInMs=other->shiftInMs;    
+    return true;
+}
+/**
     \fn audioFilterSetResample
     \brief
 */

--- a/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_audioTrackClass.h
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_audioTrackClass.h
@@ -41,4 +41,5 @@ private slots:
                        bool  enabledStateChanged(int state);
                        void  inputChanged(int signal);
                        void  codecChanged(int idx);
+                       bool  dupConfigClicked(bool a);
 };

--- a/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_audioTracks.h
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_audioTracks.h
@@ -1,40 +1,85 @@
 #include "ui_audioTracks.h"
-#define NB_MENU 4
+#include <QGridLayout>
+#include <QLabel>
+#include <QCheckBox>
+#include <QComboBox>
+#include <QPushButton>
+#define NB_MENU 32
 /**
     \class audioTrackWindow
 */
 
-#define ROLL(a,b) {a[0]=ui.b##1;a[1]=ui.b##2;a[2]=ui.b##3;a[3]=ui.b##4;}
-
 class audioTrackWindow : public QDialog
 {
 	Q_OBJECT
-
 public:
-            
+            int              trackCount;
+            QLabel           *labels[NB_MENU];
             QCheckBox        *enabled[NB_MENU];
             QComboBox        *codec[NB_MENU];
             QComboBox        *inputs[NB_MENU];
             QPushButton      *codecConf[NB_MENU];
             QPushButton      *filters[NB_MENU];
             QComboBox        *languages[NB_MENU];
+            QPushButton      *dupConfig;
 
 public:
-	audioTrackWindow()
+    audioTrackWindow(int numOfTrack)
     {
+        trackCount = numOfTrack;
         ui.setupUi(this);
-        ROLL(enabled,checkBoxEnabled);
-        ROLL(codec,comboBoxCodec);
-        ROLL(codecConf,pushButtonCodecConf);
-        ROLL(filters,pushButtonFilter);
-        ROLL(inputs,comboBoxInput);
-        ROLL(languages,comboBoxLanguage);
+        const char * clabel = QT_TRANSLATE_NOOP("qaudiotracks","Track %d");
+        char * plabel = new char[strlen(clabel)+16];
+        for (int i=0; i<NB_MENU; i++)
+        {
+            sprintf(plabel,clabel,i+1);
+            labels[i] = new QLabel(QString(plabel));
+            ui.gridLayout->addWidget(labels[i],i,0);
+            enabled[i] = new QCheckBox(QT_TRANSLATE_NOOP("qaudiotracks","Enabled"));
+            ui.gridLayout->addWidget(enabled[i],i,1);
+            inputs[i] = new QComboBox();
+            ui.gridLayout->addWidget(inputs[i],i,2);
+            languages[i] = new QComboBox();
+            ui.gridLayout->addWidget(languages[i],i,3);
+            codec[i] = new QComboBox();
+            ui.gridLayout->addWidget(codec[i],i,4);
+            codecConf[i] = new QPushButton(QT_TRANSLATE_NOOP("qaudiotracks","Configure"));
+            ui.gridLayout->addWidget(codecConf[i],i,5);
+            filters[i] = new QPushButton(QT_TRANSLATE_NOOP("qaudiotracks","Filters"));
+            ui.gridLayout->addWidget(filters[i],i,6);
+        }
+        dupConfig = new QPushButton(QT_TRANSLATE_NOOP("qaudiotracks","Duplicate down"));
+        ui.gridLayout->addWidget(dupConfig,0,7);
+        delete [] plabel;
+        showTracks(numOfTrack);
     }
-	~audioTrackWindow()
+    
+    void showTracks(int numOfTrack)
+    {
+        if (numOfTrack < trackCount)    // always show source tracks
+            numOfTrack = trackCount;
+        numOfTrack += 1;    // show one inactive track if possible
+        if (numOfTrack < 4)
+            numOfTrack = 4; // show at least 4 track
+        for (int i=0; i<NB_MENU; i++)
+        {
+            labels[i]->setVisible(i<numOfTrack);
+            enabled[i]->setVisible(i<numOfTrack);
+            inputs[i]->setVisible(i<numOfTrack);
+            languages[i]->setVisible(i<numOfTrack);
+            codec[i]->setVisible(i<numOfTrack);
+            codecConf[i]->setVisible(i<numOfTrack);
+            filters[i]->setVisible(i<numOfTrack);
+        }            
+        this->resize(100,100);  // hacky way to set size to minimum-fit
+    }
+    
+    ~audioTrackWindow()
     {
 
     }
-	Ui_DialogAudioTracks ui;
+    
+    Ui_DialogAudioTracks ui;
 
 public slots:
    

--- a/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_audioTracks.h
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_dialog/Q_audioTracks.h
@@ -48,12 +48,15 @@ public:
             filters[i] = new QPushButton(QT_TRANSLATE_NOOP("qaudiotracks","Filters"));
             ui.gridLayout->addWidget(filters[i],i,6);
         }
-        dupConfig = new QPushButton(QT_TRANSLATE_NOOP("qaudiotracks","Duplicate down"));
-        ui.gridLayout->addWidget(dupConfig,0,7);
+        dupConfig = ui.buttonBox->addButton(QT_TRANSLATE_NOOP("qaudiotracks","Duplicate first track's settings"), QDialogButtonBox::ActionRole);
         delete [] plabel;
         showTracks(numOfTrack);
     }
-    
+    void showEvent(QShowEvent *event)
+    {
+        this->adjustSize();
+        this->layout()->setSizeConstraint( QLayout::SetFixedSize ); // make dialog unresizable & always fit to content
+    }
     void showTracks(int numOfTrack)
     {
         if (numOfTrack < trackCount)    // always show source tracks
@@ -70,8 +73,7 @@ public:
             codec[i]->setVisible(i<numOfTrack);
             codecConf[i]->setVisible(i<numOfTrack);
             filters[i]->setVisible(i<numOfTrack);
-        }            
-        this->resize(100,100);  // hacky way to set size to minimum-fit
+        }
     }
     
     ~audioTrackWindow()

--- a/avidemux/qt4/ADM_userInterfaces/ADM_dialog/audioTracks.ui
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_dialog/audioTracks.ui
@@ -6,9 +6,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>620</width>
-    <height>237</height>
+    <width>200</width>
+    <height>83</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>Audio Tracks Configuration</string>
@@ -18,173 +24,9 @@
     <enum>QFormLayout::ExpandingFieldsGrow</enum>
    </property>
    <item row="0" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLabel" name="label1">
-       <property name="text">
-        <string>Track 1</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="checkBoxEnabled1">
-       <property name="text">
-        <string>Enabled</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="comboBoxInput1"/>
-     </item>
-     <item>
-      <widget class="QComboBox" name="comboBoxLanguage1"/>
-     </item>
-     <item>
-      <widget class="QComboBox" name="comboBoxCodec1"/>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButtonCodecConf1">
-       <property name="text">
-        <string>Configure</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButtonFilter1">
-       <property name="text">
-        <string>Filters</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <layout class="QGridLayout" name="gridLayout"/>
    </item>
    <item row="1" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QLabel" name="label1_2">
-       <property name="text">
-        <string>Track 2</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="checkBoxEnabled2">
-       <property name="text">
-        <string>Enabled</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="comboBoxInput2"/>
-     </item>
-     <item>
-      <widget class="QComboBox" name="comboBoxLanguage2"/>
-     </item>
-     <item>
-      <widget class="QComboBox" name="comboBoxCodec2"/>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButtonCodecConf2">
-       <property name="text">
-        <string>Configure</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButtonFilter2">
-       <property name="text">
-        <string>Filters</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="2" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
-      <widget class="QLabel" name="label1_3">
-       <property name="text">
-        <string>Track 3</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="checkBoxEnabled3">
-       <property name="text">
-        <string>Enabled</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="comboBoxInput3"/>
-     </item>
-     <item>
-      <widget class="QComboBox" name="comboBoxLanguage3"/>
-     </item>
-     <item>
-      <widget class="QComboBox" name="comboBoxCodec3"/>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButtonCodecConf3">
-       <property name="text">
-        <string>Configure</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButtonFilter3">
-       <property name="text">
-        <string>Filters</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="3" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_4">
-     <item>
-      <widget class="QLabel" name="label1_4">
-       <property name="text">
-        <string>Track 4</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="checkBoxEnabled4">
-       <property name="text">
-        <string>Enabled</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="comboBoxInput4"/>
-     </item>
-     <item>
-      <widget class="QComboBox" name="comboBoxLanguage4"/>
-     </item>
-     <item>
-      <widget class="QComboBox" name="comboBoxCodec4"/>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButtonCodecConf4">
-       <property name="text">
-        <string>Configure</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButtonFilter4">
-       <property name="text">
-        <string>Filters</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="4" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_5"/>
-   </item>
-   <item row="5" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -192,12 +34,12 @@
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>40</height>
+       <height>20</height>
       </size>
      </property>
     </spacer>
    </item>
-   <item row="6" column="0">
+   <item row="2" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>

--- a/avidemux/qt4/ADM_userInterfaces/ADM_dialog/audioTracks.ui
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_dialog/audioTracks.ui
@@ -6,12 +6,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>200</width>
-    <height>83</height>
+    <width>202</width>
+    <height>60</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+   <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -27,19 +27,6 @@
     <layout class="QGridLayout" name="gridLayout"/>
    </item>
    <item row="1" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="2" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>

--- a/avidemux_core/ADM_coreAudioFilter/include/audiofilter_conf.h
+++ b/avidemux_core/ADM_coreAudioFilter/include/audiofilter_conf.h
@@ -75,6 +75,7 @@ public: // accessor
     bool            audioFilterGetDrcMode(void) {return drcEnabled;};
     bool            audioFilterSetDrcMode(bool m) { drcEnabled=m;return true;};
     bool            audioFilterConfigure(void);
+    bool            audioFilterCopyConfig(ADM_AUDIOFILTER_CONFIG * other);
     bool            audioFilterSetResample(uint32_t newfq);  // Set 0 to disable frequency
     uint32_t        audioFilterGetResample(void);  // Set 0 to disable frequency
     bool            audioFilterSetFrameRate(FILMCONV conf);


### PR DESCRIPTION
-show minimum 4 tracks
-show one inactive track (if possible); if activated, extend the list
-button to duplicate codec and filter config of the first track to other tracks

to maintain the dialog size i used
`this->resize(100,100);  // hacky way to set size to minimum-fit`
which works on linux, but don't now if ok elsewhere...
