### PR TITLE
[UI] QSettings option for opening filter dialogs maximized

### DIFF
--- a/avidemux/qt4/ADM_UIs/src/DIA_flyDialog.cpp
+++ b/avidemux/qt4/ADM_UIs/src/DIA_flyDialog.cpp
@@ -29,6 +29,7 @@
 
 #include "ADM_toolkitQt.h"
 #include "ADM_vidMisc.h"
+#include "ADM_QSettings.h"
 #include "prefs.h"
 
 /**
@@ -675,6 +676,19 @@ bool FlyDialogEventFilter::eventFilter(QObject *obj, QEvent *event)
     
     ADM_info("Interval = %d ms\n",incrementUs);
     timer.stop();
+    
+    QSettings *qset = qtSettingsCreate();
+    if(qset)
+    {
+        qset->beginGroup("flyDialog");
+        if (qset->value("openMaximized", 0).toInt())
+        {
+            parent->setWindowState(Qt::WindowMaximized);
+        }
+        qset->endGroup();
+        delete qset;
+        qset = NULL;
+    }
     
     bool swapWheel = false;
     prefs->get(FEATURES_SWAP_MOUSE_WHEEL,&swapWheel);

--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
@@ -794,6 +794,11 @@ MainWindow::MainWindow(const vector<IScriptEngine*>& scriptEngines) : _scriptEng
     darkThemeAction->setCheckable(true);
     ui.menuThemes->addAction(darkThemeAction);
     connect(darkThemeAction,SIGNAL(triggered(bool)),this,SLOT(setDarkThemeSlot(bool)));
+    
+    filterPrefMaximizedAction = new QAction(QT_TRANSLATE_NOOP("qgui2","Open filter dialogs maximized"),this);
+    filterPrefMaximizedAction->setCheckable(true);
+    ui.menuFilters->addAction(filterPrefMaximizedAction);
+    connect(filterPrefMaximizedAction,SIGNAL(triggered(bool)),this,SLOT(setMaximizedFiltersSlot(bool)));
 
     this->installEventFilter(this);
     slider->installEventFilter(this);
@@ -1753,6 +1758,7 @@ void MainWindow::setDefaultThemeSlot(bool b)
     ui.menuView->setPalette(x); \
     ui.menuToolbars->setPalette(x); \
     ui.menuThemes->setPalette(x); \
+    ui.menuFilters->setPalette(x); \
     ui.menuVideo->setPalette(x); \
     ui.menuAudio->setPalette(x); \
     ui.menuAuto->setPalette(x); \
@@ -1886,6 +1892,35 @@ void MainWindow::setDarkThemeSlot(bool b)
         delete qset;
         qset = NULL;
     }
+}
+
+/**
+    \fn     setFilterSettings
+    \brief  Load Filter QSettings.
+*/
+void MainWindow::setFilterSettings(QSettings *qset)
+{
+    if (qset == NULL) return;
+    qset->beginGroup("flyDialog");
+    filterPrefMaximizedAction->setChecked(qset->value("openMaximized", 0).toInt());
+    qset->endGroup();    
+}
+
+/**
+    \fn     setMaximizedFiltersSlot
+    \brief  Update "Open filter dialogs maximized" settings.
+*/
+void MainWindow::setMaximizedFiltersSlot(bool b)
+{
+    QSettings *qset = qtSettingsCreate();
+    if(qset)
+    {
+        qset->beginGroup("flyDialog");
+        qset->setValue("openMaximized", (b?1:0));
+        qset->endGroup();
+        delete qset;
+        qset = NULL;
+    }   
 }
 
 /**
@@ -2559,6 +2594,9 @@ uint8_t initGUI(const vector<IScriptEngine*>& scriptEngines)
         mw->ui.horizontalSlider_2->setValue(qset->value("volume", 100).toInt());
         mw->ui.horizontalSlider_2->blockSignals(false);
         qset->endGroup();
+        
+        mw->setFilterSettings(qset);
+        
         // Hack: allow to drop other Qt-specific settings on application restart
         char *dropSettingsOnLaunch = getenv("ADM_QT_DROP_SETTINGS");
         if(dropSettingsOnLaunch && !strcmp("1",dropSettingsOnLaunch))

--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.h
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.h
@@ -9,6 +9,7 @@
 #include <QSlider>
 #include <QWidget>
 #include <QtCore/QTimer>
+#include <QSettings>
 #include <string>
 
 #include "ADM_mwNavSlider.h"
@@ -126,6 +127,7 @@ public:
 
     void setLightTheme(void);
     void setDarkTheme(void);
+    void setFilterSettings(QSettings *qset);
 
     static void updateCheckDone(int version, const std::string &date, const std::string &downloadLink);
     static MainWindow *mainWindowSingleton;
@@ -146,6 +148,7 @@ protected:
     QAction *defaultThemeAction;
     QAction *lightThemeAction;
     QAction *darkThemeAction;
+    QAction *filterPrefMaximizedAction;
     QString defaultStyle;
 #ifdef BROKEN_PALETTE_PROPAGATION
     std::vector<QMenu *> subMenus;
@@ -255,6 +258,7 @@ private slots:
     void setDefaultThemeSlot(bool b);
     void setLightThemeSlot(bool b);
     void setDarkThemeSlot(bool b);
+    void setMaximizedFiltersSlot(bool b);
 
     void closeEvent(QCloseEvent *event)
     {

--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/gui2.ui
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/gui2.ui
@@ -140,8 +140,14 @@
       <string>T&amp;heme</string>
      </property>
     </widget>
+    <widget class="QMenu" name="menuFilters">
+     <property name="title">
+      <string>F&amp;ilters</string>
+     </property>
+    </widget>
     <addaction name="menuToolbars"/>
     <addaction name="menuThemes"/>
+    <addaction name="menuFilters"/>
    </widget>
    <widget class="QMenu" name="menuAuto">
     <property name="title">


### PR DESCRIPTION
View menu / Filters / Open filter dialogs maximized
If enabled, it can spare the manual resizing of filter's dialogs _every time_.