### PR TITLE
CMake: Ensure git rev SHAs aren't abbreviated

### DIFF
--- a/cmake/FindGitSvn.cmake
+++ b/cmake/FindGitSvn.cmake
@@ -47,7 +47,7 @@ MACRO(admGetGitRevision _dir _rev)
        MESSAGE(STATUS "Top dir is <${topdir}>")
        #MESSAGE(STATUS "COMMAND  ${GIT_EXECUTABLE} log --format=oneline -1   ${topdir}")
        EXECUTE_PROCESS(
-               COMMAND echo  log --format=oneline -1   ${topdir}
+               COMMAND echo  log --format=oneline --no-abbrev -1   ${topdir}
                COMMAND xargs ${GIT_EXECUTABLE} 
                COMMAND head -c 11
                WORKING_DIRECTORY ${_dir} 


### PR DESCRIPTION
When building from the repo, `ADM_SUBVERSION` is partly generated from the first 11 characters of a `git log --format=oneline` output line. This can misparse the revision string if they're allowed to be abbreviated, which can leave them at only 8 or 9 characters. The resulting `ADM_SUBVERSION`, e.g. `221228_abcde0123 (`, will break `printf` calls in the code due to the unmatched open paren.

Adding `--no-abbrev` to the command ensures that the full 40-character SHA  is output, which can then be truncated to whatever length the script needs.