### PR TITLE
[bootstrap] Harmonize builddir names

### DIFF
--- a/bootStrap.bash
+++ b/bootStrap.bash
@@ -325,7 +325,7 @@ fi
 if [ "x$do_plugins" = "x1" -a "x$do_cli" = "x1" ] ; then 
         echo "** Plugins CLI **"
         cd $TOP
-        Process buildPluginsCLI ../avidemux_plugins "-DPLUGIN_UI=CLI $EXTRA_CMAKE_DEFS"
+        Process buildPluginsCli ../avidemux_plugins "-DPLUGIN_UI=CLI $EXTRA_CMAKE_DEFS"
 fi
 if [ "x$do_plugins" = "x1"  ] ; then 
         echo "** Plugins Settings **"

--- a/bootStrapHaikuOS.bash
+++ b/bootStrapHaikuOS.bash
@@ -194,7 +194,7 @@ fi
 if [ "x$do_plugins" = "x1" -a "x$do_cli" = "x1" ] ; then 
         echo "** Plugins CLI **"
         cd $TOP
-        Process buildPluginsCLI ../avidemux_plugins -DPLUGIN_UI=CLI
+        Process buildPluginsCli ../avidemux_plugins -DPLUGIN_UI=CLI
 fi
 
 echo "** Preparing debs **"

--- a/bootStrapMacOS_Monterey.arm64.sh
+++ b/bootStrapMacOS_Monterey.arm64.sh
@@ -334,7 +334,7 @@ fi
 if [ "x$do_plugins" = "x1" -a "x$do_cli" = "x1" ] ; then
         echo "** Plugins CLI **"
         cd $TOP
-        Process buildPluginsCLI ../avidemux_plugins "-DPLUGIN_UI=CLI $EXTRA_CMAKE_DEFS"
+        Process buildPluginsCli ../avidemux_plugins "-DPLUGIN_UI=CLI $EXTRA_CMAKE_DEFS"
 fi
 if [ "x$do_plugins" = "x1" ] ; then
         echo "** Plugins Settings **"

--- a/bootStrapOsx_Catalina.bash
+++ b/bootStrapOsx_Catalina.bash
@@ -350,7 +350,7 @@ fi
 if [ "x$do_plugins" = "x1" -a "x$do_cli" = "x1" ] ; then
         echo "** Plugins CLI **"
         cd $TOP
-        Process buildPluginsCLI ../avidemux_plugins "-DPLUGIN_UI=CLI $EXTRA_CMAKE_DEFS"
+        Process buildPluginsCli ../avidemux_plugins "-DPLUGIN_UI=CLI $EXTRA_CMAKE_DEFS"
 fi
 if [ "x$do_plugins" = "x1" ] ; then
         echo "** Plugins Settings **"

--- a/bootStrapOsx_HighSierra.bash
+++ b/bootStrapOsx_HighSierra.bash
@@ -303,7 +303,7 @@ fi
 if [ "x$do_plugins" = "x1" -a "x$do_cli" = "x1" ] ; then
         echo "** Plugins CLI **"
         cd $TOP
-        Process buildPluginsCLI ../avidemux_plugins "-DPLUGIN_UI=CLI $EXTRA_CMAKE_DEFS"
+        Process buildPluginsCli ../avidemux_plugins "-DPLUGIN_UI=CLI $EXTRA_CMAKE_DEFS"
 fi
 if [ "x$do_plugins" = "x1" ] ; then
         echo "** Plugins Settings **"

--- a/bootStrapOsx_Sierra.bash
+++ b/bootStrapOsx_Sierra.bash
@@ -302,7 +302,7 @@ fi
 if [ "x$do_plugins" = "x1" -a "x$do_cli" = "x1" ] ; then
         echo "** Plugins CLI **"
         cd $TOP
-        Process buildPluginsCLI ../avidemux_plugins "-DPLUGIN_UI=CLI $EXTRA_CMAKE_DEFS"
+        Process buildPluginsCli ../avidemux_plugins "-DPLUGIN_UI=CLI $EXTRA_CMAKE_DEFS"
 fi
 if [ "x$do_plugins" = "x1" ] ; then
         echo "** Plugins Settings **"


### PR DESCRIPTION
The bootstrap scripts were using "buildCli" as the name of the CLI builddir, but then the CLI plugins were built in a directory named "buildPluginsCLI", a difference in casing that just seems unnecessarily confusing.

I normalized them to "buildCli" and "buildPluginsCli", though I'd be happy to go the other way ("CLI" for both) if preferred.
