### PR TITLE
[cmake] Don't set CMAKE_EDIT_COMMAND

### DIFF
--- a/bootStrap.bash
+++ b/bootStrap.bash
@@ -65,7 +65,7 @@ Process()
                 mkdir $BUILDDIR || fail mkdir
         fi
         cd $BUILDDIR 
-        cmake $COMPILER $PKG $FAKEROOT $QT_FLAVOR -DCMAKE_EDIT_COMMAND=vim $INSTALL_PREFIX $EXTRA $BUILD_QUIRKS $ASAN $DEBUG -G "$BUILDER" $SOURCEDIR || fail cmakeZ
+        cmake $COMPILER $PKG $FAKEROOT $QT_FLAVOR $INSTALL_PREFIX $EXTRA $BUILD_QUIRKS $ASAN $DEBUG -G "$BUILDER" $SOURCEDIR || fail cmakeZ
         make  $PARAL >& /tmp/log$BUILDDIR || fail "make, result in /tmp/log$BUILDDIR"
 	if  [ "x$PKG" != "x" ] ; then
           $FAKEROOT_COMMAND make package DESTDIR=$FAKEROOT_DIR/tmp || fail package

--- a/bootStrapHaikuOS.bash
+++ b/bootStrapHaikuOS.bash
@@ -37,7 +37,7 @@ Process()
         rm -Rf ./$BUILDDIR
         mkdir $BUILDDIR || fail mkdir
         cd $BUILDDIR 
-        cmake $PKG -DCMAKE_EDIT_COMMAND=mcedit -DCMAKE_CXX_FLAGS="-D__STDC_CONSTANT_MACROS" -DPTHREAD_INCLUDE_DIR=/boot/develop/headers/posix -DAVIDEMUX_SOURCE_DIR=$TOP -DCMAKE_INSTALL_PREFIX="$BASE_INSTALL_DIR" $EXTRA $DEBUG -G "$BUILDER" $SOURCEDIR || fail cmakeZ
+        cmake $PKG -DCMAKE_CXX_FLAGS="-D__STDC_CONSTANT_MACROS" -DPTHREAD_INCLUDE_DIR=/boot/develop/headers/posix -DAVIDEMUX_SOURCE_DIR=$TOP -DCMAKE_INSTALL_PREFIX="$BASE_INSTALL_DIR" $EXTRA $DEBUG -G "$BUILDER" $SOURCEDIR || fail cmakeZ
         make -j 2 > /tmp/log$BUILDDIR || fail make
 }
 printModule()

--- a/bootStrapOsx_Catalina.bash
+++ b/bootStrapOsx_Catalina.bash
@@ -80,7 +80,7 @@ Process()
         fi
         mkdir -p $BUILDDIR || fail mkdir
         cd $BUILDDIR 
-        cmake $COMPILER $PKG $FAKEROOT -DCMAKE_INSTALL_PREFIX="$PREFIX" -DCMAKE_EDIT_COMMAND=vim -DAVIDEMUX_SOURCE_DIR=$TOP -DAVIDEMUX_VERSION="$ADM_VERSION" $EXTRA $FLAVOR $DEBUG -G "$BUILDER" $SOURCEDIR || fail cmakeZ
+        cmake $COMPILER $PKG $FAKEROOT -DCMAKE_INSTALL_PREFIX="$PREFIX" -DAVIDEMUX_SOURCE_DIR=$TOP -DAVIDEMUX_VERSION="$ADM_VERSION" $EXTRA $FLAVOR $DEBUG -G "$BUILDER" $SOURCEDIR || fail cmakeZ
         make -j 2 > /tmp/log$BUILDDIR || fail make
         echo "** installing at $FAKEROOT_DIR **"
         make install DESTDIR=$FAKEROOT_DIR || fail install

--- a/bootStrapOsx_HighSierra.bash
+++ b/bootStrapOsx_HighSierra.bash
@@ -89,7 +89,7 @@ Process()
         fi
         mkdir -p $BUILDDIR || fail mkdir
         cd $BUILDDIR 
-        cmake $COMPILER $PKG $FAKEROOT -DCMAKE_INSTALL_PREFIX="$PREFIX" -DCMAKE_EDIT_COMMAND=vim -DAVIDEMUX_SOURCE_DIR=$TOP -DAVIDEMUX_VERSION="$ADM_VERSION" $EXTRA $FLAVOR $DEBUG -G "$BUILDER" $SOURCEDIR || fail cmakeZ
+        cmake $COMPILER $PKG $FAKEROOT -DCMAKE_INSTALL_PREFIX="$PREFIX" -DAVIDEMUX_SOURCE_DIR=$TOP -DAVIDEMUX_VERSION="$ADM_VERSION" $EXTRA $FLAVOR $DEBUG -G "$BUILDER" $SOURCEDIR || fail cmakeZ
         make -j 2 > /tmp/log$BUILDDIR || fail make
         echo "** installing at $FAKEROOT_DIR **"
         make install DESTDIR=$FAKEROOT_DIR || fail install

--- a/bootStrapOsx_Sierra.bash
+++ b/bootStrapOsx_Sierra.bash
@@ -88,7 +88,7 @@ Process()
         fi
         mkdir -p $BUILDDIR || fail mkdir
         cd $BUILDDIR 
-        cmake $COMPILER $PKG $FAKEROOT -DCMAKE_INSTALL_PREFIX="$PREFIX" -DCMAKE_EDIT_COMMAND=vim -DAVIDEMUX_SOURCE_DIR=$TOP -DAVIDEMUX_VERSION="$ADM_VERSION" $EXTRA $FLAVOR $DEBUG -G "$BUILDER" $SOURCEDIR || fail cmakeZ
+        cmake $COMPILER $PKG $FAKEROOT -DCMAKE_INSTALL_PREFIX="$PREFIX" -DAVIDEMUX_SOURCE_DIR=$TOP -DAVIDEMUX_VERSION="$ADM_VERSION" $EXTRA $FLAVOR $DEBUG -G "$BUILDER" $SOURCEDIR || fail cmakeZ
         make -j 2 > /tmp/log$BUILDDIR || fail make
         echo "** installing at $FAKEROOT_DIR **"
         make install DESTDIR=$FAKEROOT_DIR || fail install


### PR DESCRIPTION
`CMAKE_EDIT_COMMAND` is mean to be an internal variable, used only for implementing the `make edit_cache` target of Makefile Generators. It's supposed to contain the path to a CMake editor like `ccmake` or `cmake-gui`, and will be called with arguments not accepted by `vim`, `mcedit`, or any other generic editor.

Ref: https://cmake.org/cmake/help/latest/variable/CMAKE_EDIT_COMMAND.html

Here's what happens if you run `make edit_cache` with the `CMAKE_EDIT_COMMAND` set to `vim` as in the bootstrap scripts:

```console
$ cd buildCli
$ make edit_cache
Running CMake cache editor...
vim -S.../avidemux2/avidemux/cli -B.../avidemux2/buildCli
VIM - Vi IMproved 9.0 (2022 Jun 28, compiled Dec 14 2022 00:00:00)
Garbage after option argument: "-S.../avidemux2/avidemux/cli"
More info with: "vim -h"
make: *** [Makefile:74: edit_cache] Error 1
```