### PR TITLE
[GUI] alert user if loading/save is done

### DIFF
--- a/avidemux/cli/ADM_userInterfaces/ADM_gui2/gui_none.cpp
+++ b/avidemux/cli/ADM_userInterfaces/ADM_gui2/gui_none.cpp
@@ -213,4 +213,7 @@ void UI_notifyWarning(const char *message, int timeoutMs)
 {}
 void UI_notifyError(const char *message, int timeoutMs)
 {}
+
+void UI_needsAttention(void);
+{}
 // EOF

--- a/avidemux/common/ADM_commonUI/GUI_ui.h
+++ b/avidemux/common/ADM_commonUI/GUI_ui.h
@@ -62,6 +62,8 @@ void UI_notifyInfo(const char *message, int timeoutMs);
 void UI_notifyWarning(const char *message, int timeoutMs);
 void UI_notifyError(const char *message, int timeoutMs);
 
+void UI_needsAttention(void);
+
 /* We need to know whether auto-repeat is firing */
 bool UI_navigationButtonsPressed(void);
 

--- a/avidemux/common/gui_main.cpp
+++ b/avidemux/common/gui_main.cpp
@@ -1078,6 +1078,7 @@ int A_openVideo (const char *name)
     }
 
     delete[] longname;
+    UI_needsAttention();    // loading done, alert the user
     return 1;
 }
 /**
@@ -1169,6 +1170,7 @@ int A_appendVideo (const char *name)
     ReSync();
     GUI_setCurrentFrameAndTime();
     UI_setMarkers (video_body->getMarkerAPts(),video_body->getMarkerBPts());
+    UI_needsAttention();    // loading done, alert the user
     return 1;
 }
 

--- a/avidemux/common/gui_savenew.cpp
+++ b/avidemux/common/gui_savenew.cpp
@@ -101,6 +101,7 @@ int A_Save(const char *name)
     ADM_slaveSendResult(r);
     A_Rewind();
     GUI_GoToTime(current);
+    UI_needsAttention();    // saving done, alert the user
     return (int)r;
 }
 

--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
@@ -3628,6 +3628,14 @@ void UI_notifyError(const char *message, int timeoutMs)
 {
     ((MainWindow *)QuiMainWindows)->notifyStatusBar(QT_TRANSLATE_NOOP("qgui2","ERROR: %1"), message, timeoutMs);
 }
+
+/**
+    \fn UI_needsAttention
+*/
+void UI_needsAttention(void)
+{
+    QApplication::alert(NULL);
+}
 /**
  * \fn dtor
  */


### PR DESCRIPTION
If the application is put to the background, it alerts the user that long lasting loading/saving is done
According to Qt documentation of _QApplication::alert_ :

> On macOS, this works more at the application level and will cause the application icon to bounce in the dock.
>
> On Windows, this causes the window's taskbar entry to flash for a time. If msec is zero, the flashing will stop and the taskbar entry will turn a different color (currently orange).
> 
> On X11, this will cause the window to be marked as "demands attention", the window must not be hidden (i.e. not have hide() called on it, but be visible in some sort of way) in order for this to work.