### PR TITLE
fix(requirements): Add libpcre3-dev to Ubuntu prereq

### DIFF
--- a/cross-compiling.txt
+++ b/cross-compiling.txt
@@ -7,7 +7,7 @@
 
 1. Install MXE (M cross environment) dependencies as described in
 
-    http://mxe.cc/#requirements
+    http://mxe.cc/#requirements (plus `libpcre3-dev`)
 
 for your respective Linux distribution, then run the script mxe-setup.sh from
 a directory *outside of Avidemux top source directory*. This script will


### PR DESCRIPTION
- Myself and others have consistently had the `mxe/mxe-setup.sh` script fail for `ERROR: could not get https://sourceforge.net/projects/pcre/files/pcre/8.37/pcre-8.37.tar.bz2 is the internet available?`
- A simple fix is to just add the development package for pcre to the prereq, `libpcre3-dev`
- The issue can be reproduced as follows:
  - Install Ubuntu 22.10
  - `apt update && apt upgrade`
  - `reboot`
  - Install "Debian and derivatives" prerequisites, https://mxe.cc/#requirements
  - `reboot`
  - `cd`
  - `git clone https://github.com/mean00/avidemux2.git`
  - `mkdir cross-build`
  - `cd cross-build`
  - `bash ../avidemux2/mxe/mxe-setup.sh`

```
Failed to build package glib for target x86_64-pc-linux-gnu!
------------------------------------------------------------
tmp-glib-x86_64-pc-linux-gnu/glib-2.70.2/meson.build:2002:2: ERROR: could not get https://sourceforge.net/projects/pcre/files/pcre/8.37/pcre-8.37.tar.bz2 is the internet available?
A full log can be found at /home/****/cross-build/mxe/tmp-glib-x86_64-pc-linux-gnu/glib-2.70.2.build_/meson-logs/meson-log.txt
WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.
make[1]: *** [Makefile:901: build-only-glib_x86_64-pc-linux-gnu] Error 1
make[1]: Leaving directory '/home/****/cross-build/mxe'
real	0m41.384s
user	0m8.591s
sys	0m1.896s
```