### PR TITLE
fix filters causing MXE build failure

### DIFF
--- a/avidemux_plugins/ADM_videoFilters6/fluxSmooth/ADM_vidFlux.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/fluxSmooth/ADM_vidFlux.cpp
@@ -135,7 +135,7 @@ int frame=nextFrame++;
             ADM_assert(prev);
 
 		   	DoFlux *flux=	DoFilter_C;	
-#if defined(ADM_CPU_X86) && defined(ASM_FLUX)
+#if defined(ADM_CPU_X86_32) && defined(ASM_FLUX)
             flux=DoFilter_MMX;
 #endif
 // now we have everything

--- a/avidemux_plugins/ADM_videoFilters6/fluxSmooth/ADM_vidFluxAsm.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/fluxSmooth/ADM_vidFluxAsm.cpp
@@ -178,7 +178,7 @@ void attribute_used ADMVideoFlux::DoFilter_C(
 	ADM_assert(ycnt == 0);
 
 }
-#ifdef ADM_CPU_X86
+#ifdef ADM_CPU_X86_32
 /*
 	__asm movq mm2, mm0 \
 	__asm movq mm3, mm1 \

--- a/avidemux_plugins/ADM_videoFilters6/ivtcDupeRemover/ADM_ivtcDupeRemover.cpp
+++ b/avidemux_plugins/ADM_videoFilters6/ivtcDupeRemover/ADM_ivtcDupeRemover.cpp
@@ -22,7 +22,7 @@
 #include "ivtcDupeRemover.h"
 #include "ivtcDupeRemover_desc.cpp"
 
-#if defined( ADM_CPU_X86) && !defined(_MSC_VER)
+#if defined( ADM_CPU_X86_32) && !defined(_MSC_VER)
         #define CAN_DO_INLINE_X86_ASM
 #endif
 


### PR DESCRIPTION
not a real fix, just makes these filters buildable
32bit at&t syntax asm;  WONTFIX