### PR TITLE
Add file system case-sensitive check

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Avidemux is a simple cross-platform video editor for Linux, Windows and macOS.
 # Build from source
 
 To get Avidemux source code from the main repository and the translations,
-run the following commands in a directory located on a case-sensitive file system:
+run the following commands in a directory located on a **_case-sensitive_** file system:
 ```
 git clone --recursive https://github.com/mean00/avidemux2.git
 cd avidemux2

--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ Avidemux is a simple cross-platform video editor for Linux, Windows and macOS.
 To get Avidemux source code from the main repository and the translations,
 run the following commands in a directory located on a case-sensitive file system:
 ```
-git clone https://github.com/mean00/avidemux2.git
+git clone --recursive https://github.com/mean00/avidemux2.git
 cd avidemux2
-git submodule update --init --recursive
 ```
 
 

--- a/bootStrapMacOS_Monterey.arm64.sh
+++ b/bootStrapMacOS_Monterey.arm64.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Bootstrapper to semi-automatically build avidemux from source on OSX
 # (c) Mean 2009
+source "./checkCaseSensitivity.sh"
+
 export MAJOR=`cat cmake/avidemuxVersion.cmake | grep "VERSION_MAJOR " | sed 's/..$//g' | sed 's/^.*"//g'`
 export MINOR=`cat cmake/avidemuxVersion.cmake | grep "VERSION_MINOR " | sed 's/..$//g' | sed 's/^.*"//g'`
 export PATCH=`cat cmake/avidemuxVersion.cmake | grep "VERSION_P " | sed 's/..$//g' | sed 's/^.*"//g'`
@@ -28,6 +30,11 @@ external_libmp4v2=1
 
 export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
 export MACOSX_DEPLOYMENT_TARGET=$(xcrun --sdk macosx --show-sdk-version)
+
+if ! isCaseSensitive; then
+    >&2 echo "Error: filesystem is not case sensitive"
+    exit 1
+fi
 
 test -f $HOME/myCC  && export COMPILER="-DCMAKE_C_COMPILER=$HOME/myCC -DCMAKE_CXX_COMPILER=$HOME/myC++"
 

--- a/checkCaseSensitivity.sh
+++ b/checkCaseSensitivity.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+isCaseSensitive()
+{
+        test_dir=casetest-$RANDOM$RANDOM
+        mkdir "$test_dir"
+        touch "$test_dir/casetest"
+        touch "$test_dir/caseTEST"
+        check_num=$(find ./"$test_dir" -type f -name 'case*' | wc -l)
+
+         if [ "$check_num" -eq 2 ]; then
+            rm -rf "$test_dir"
+            return 0
+         else
+            rm -rf "$test_dir"
+            return 1
+        fi
+}


### PR DESCRIPTION
The build requires the file system to be case-sensitive and will proceed and fail even if it's case-insensitive (which is the default on macOS, unfortunately).

Add isCaseSensitive function to avoid this pitfall early on.

This PR also tries to improve documentation by highlighting this requirement and removing the extra step for git submodules. After finalising the review/feedback and the script, I want to add this to other Mac build scripts.
