### PR TITLE
Exec options must be %U instead of %f

### DIFF
--- a/avidemux/qt4/xdg_data/org.avidemux.Avidemux.desktop.in
+++ b/avidemux/qt4/xdg_data/org.avidemux.Avidemux.desktop.in
@@ -2,7 +2,7 @@
 Name=Avidemux
 GenericName=Video Editor
 Comment=Multiplatform video editor
-Exec=avidemux3_${QT_EXTENSION} %f
+Exec=avidemux3_${QT_EXTENSION} %U
 Icon=org.avidemux.Avidemux
 Terminal=false
 Type=Application


### PR DESCRIPTION
From Desktop Entry Specification: https://specifications.freedesktop.org/desktop-entry-spec/1.1/exec-variables.html

%U is preferred to open multiples file or URLs

As example in an Debian unstable 
```
$ grep Exec /usr/share/applications/*|grep -c %f
14
marillat~  
$ grep Exec /usr/share/applications/*|grep -c %U
35
```
