### PR TITLE
demuxers/Matroska: add FFV1 codec ID mapping

### DIFF
--- a/avidemux_plugins/ADM_demuxers/Matroska/ADM_mkvTrackType.cpp
+++ b/avidemux_plugins/ADM_demuxers/Matroska/ADM_mkvTrackType.cpp
@@ -67,6 +67,7 @@ MKVCC mkvCC[]=
   {"V_MPEG4/ISO/ASP",1,0,"DIVX"},
   {"V_MJPEG",1,0,"MJPG"},
   {"V_AV1",1,0,"av01"},
+  {"V_FFV1",1,0,"FFV1"},
   {"V_PRORES",1,0,"apco"}, // dummy fourcc, we need to decode frame header to detect the real one
   // Filler
   {"AVIDEMUX_RULES",1,0,"DIV2"} // DUMMY


### PR DESCRIPTION
Maps Matroska CodecID V_FFV1 to internal FourCC FFV1.

Without this mapping, FFV1-in-MKV opens with Video FCC 00000000, decoder lookup fails, and Avidemux falls back to the RGB/raw codec.

Tested with an FFV1 v3.4 MKV, 720x480, YUV 4:2:0 8-bit. After this one-line mapping, the file opens using the lavcodec decoder path and displays correctly.