### PR TITLE
Set desktop file name for the application

### DIFF
--- a/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
+++ b/avidemux/qt4/ADM_userInterfaces/ADM_gui/Q_gui2.cpp
@@ -2923,6 +2923,7 @@ int UI_Init(int nargc, char **nargv)
     QApplication::setAttribute(Qt::AA_DisableWindowContextHelpButton);
 #endif
     myApplication = new myQApplication(global_argc, global_argv);
+    myApplication->setDesktopFileName("org.avidemux.Avidemux");
     myApplication->connect(myApplication, SIGNAL(lastWindowClosed()), myApplication, SLOT(quit()));
     myApplication->connect(myApplication, SIGNAL(aboutToQuit()), myApplication, SLOT(cleanup()));
 #ifdef __APPLE__


### PR DESCRIPTION
This ensures that the XDG toplevel app ID matches with the desktop file name, so Wayland compositors could match the window with the application and show the appropriate icon for them.

Without this change, the app ID is `avidemux3_qt5` (following the executable name), but the desktop file is called as [`org.avidemux.Avidemux`](https://github.com/mean00/avidemux2/blob/eea13ca1b22abf9e297f0c82ddb134f55d28c289/avidemux/qt4/xdg_data/org.avidemux.Avidemux.desktop.in).

References:
- https://github.com/qt/qtbase/blob/bf1ae5862807ec2b9a411506d59ccd566937a4c7/src/plugins/platforms/wayland/qwaylandwindow.cpp#L152C20-L177
- https://wayland.app/protocols/xdg-shell#xdg_toplevel:request:set_app_id