### PR TITLE
osxInstaller: add the build Qt's lib dir to fixup_bundle search dirs

### DIFF
--- a/avidemux/osxInstaller/CMakeLists.txt
+++ b/avidemux/osxInstaller/CMakeLists.txt
@@ -51,6 +51,16 @@ LIST(APPEND bundleDirs  "${BUNDLE}/Contents/Resources/lib")
 IF(ENABLE_QT6)
   # A gross hack to work around the failure to resolve @loader_path for libbrotli.
   LIST(APPEND bundleDirs "/usr/local/lib")
+  # Let fixup_bundle resolve the @rpath/Qt*.framework references carried by the
+  # Qt platform and style plugins against the Qt actually used for this build
+  # (Homebrew on arm64 or Intel, or a custom MYQT installation alike). Whether
+  # the app binaries otherwise carry a usable rpath for this depends on the
+  # install-rpath machinery, which e.g. a LIBRARY_PATH environment variable
+  # silently disables.
+  IF(Qt6_DIR)
+    get_filename_component(ADM_QT_LIB_DIR "${Qt6_DIR}/../.." ABSOLUTE)
+    LIST(APPEND bundleDirs "${ADM_QT_LIB_DIR}")
+  ENDIF()
 ENDIF()
 #
 


### PR DESCRIPTION
Appends Qt's lib dir (from Qt6_DIR) to the packaging search path, so packaging stops depending on which rpaths make it into the installed binaries.

If LIBRARY_PATH is set while building (a common leftover from troubleshooting Homebrew issues), CMake stops writing /opt/homebrew/lib into the install rpaths, and fixup_bundle can no longer resolve the Qt plugin @rpath references. Packaging dies on ARM Macs because the only fallback dir is /usr/local/lib.

The build system already knows where Qt is, so the appended dir is always correct: /opt/homebrew/lib on ARM, /usr/local/lib on x86, or your own folder if you built a custom Qt. Packaging verified with SDL3 on and off.